### PR TITLE
feat: load ja-dic as the default system dictionary

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,6 +59,9 @@ No external ELPA packages required.
 (require 'nskk)
 (nskk-global-mode 1)
 
+;; NSKK uses Emacs's built-in ja-dic by default when available.
+;; You can still override it with `nskk-dict-system-dictionary-files'.
+
 ;; After nskk-global-mode is enabled:
 ;; C-j       → switch to hiragana input (from ascii mode)
 ;; C-x C-j   → toggle nskk-mode on/off in current buffer

--- a/nskk-dictionary.el
+++ b/nskk-dictionary.el
@@ -61,6 +61,7 @@
 ;; - `nskk-dict-register-word'            -- register a new word
 ;; - `nskk-dict-load-user-dictionary'     -- load user dictionary from file
 ;; - `nskk-dict-load-system-dictionaries' -- load system dictionaries
+;; - `nskk-dict-load-ja-dic'              -- load Emacs built-in ja-dic data
 ;; - `nskk-dict-save-user-dictionary'     -- persist user dictionary to file
 ;; - `nskk-dict-initialize'               -- initialize all dictionaries
 
@@ -97,6 +98,13 @@ and common system locations."
 
 (defcustom nskk-dict-cache-enabled t
   "When non-nil, enable on-disk caching for system dictionaries."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'nskk-dictionary)
+
+(defcustom nskk-dict-use-ja-dic t
+  "When non-nil, use Emacs's built-in ja-dic as the default system dictionary.
+Only used when `nskk-dict-system-dictionary-files' is nil."
   :type 'boolean
   :safe #'booleanp
   :group 'nskk-dictionary)
@@ -207,9 +215,70 @@ Returns entry count (0 if no readable files or no entries found)."
                                append (nskk--dict-parse-file-to-entries file))))
     (when all-entries
       (nskk-prolog-trie-bulk-assert 'system-dict-entry 2 all-entries)
-      (when nskk-dict-cache-enabled
-        (nskk--dict-save-system-dict-cache all-entries dict-files)))
+    (when nskk-dict-cache-enabled
+      (nskk--dict-save-system-dict-cache all-entries dict-files)))
     (length all-entries)))
+
+(defvar nskk--dict-ja-dic-code-table nil
+  "Hash table mapping ja-dic compact kana codes to Emacs characters.")
+
+(defun nskk--dict-ja-dic-decode-key (codes)
+  "Decode ja-dic compact key CODES into an NSKK reading string."
+  (unless nskk--dict-ja-dic-code-table
+    (setq nskk--dict-ja-dic-code-table (make-hash-table :test #'eql))
+    (cl-loop for ch from #x3041 to #x3096
+             for jis = (encode-char ch 'japanese-jisx0208)
+             when jis do (puthash (- (logand jis #xFF) 32) ch nskk--dict-ja-dic-code-table)))
+  (apply #'string
+         (mapcar (lambda (code)
+                   (cond ((zerop code) ?ー)
+                         ((< code 0) (- code))
+                         (t (or (gethash code nskk--dict-ja-dic-code-table)
+                                (error "NSKK: Unknown ja-dic compact code %S" code)))))
+                 codes)))
+
+(defun nskk--dict-ja-dic-flatten-node (node prefix)
+  "Recursively flatten ja-dic NODE using PREFIX compact codes."
+  (let* ((code (car node))
+         (rest (cdr node))
+         (path (append prefix (list code)))
+         (cands (car rest))
+         (entries nil))
+    (when (and (listp cands) (stringp (car cands)))
+      (push (cons (nskk--dict-ja-dic-decode-key path) (reverse cands)) entries)
+      (setq rest (cdr rest)))
+    (when (eq (car rest) t) (setq rest (cdr rest)))
+    (dolist (child rest)
+      (when (consp child)
+        (setq entries (nconc entries (nskk--dict-ja-dic-flatten-node child path)))))
+    entries))
+
+(defun nskk--dict-ja-dic-flatten-tree (tree)
+  "Flatten ja-dic TREE into a list of (key . candidates) entries."
+  (cl-loop for node in (cdr tree)
+           when (consp node)
+           nconc (nskk--dict-ja-dic-flatten-node node nil)))
+
+(defun nskk-dict-load-ja-dic ()
+  "Load Emacs built-in `ja-dic' data as `system-dict-entry' facts.
+Returns `system' when entries were loaded successfully, or nil otherwise."
+  (condition-case err
+      (when (load-library "ja-dic/ja-dic")
+        (let ((entries (append (when (boundp 'skkdic-okuri-nasi)
+                                 (nskk--dict-ja-dic-flatten-tree skkdic-okuri-nasi))
+                               (when (boundp 'skkdic-okuri-ari)
+                                 (nskk--dict-ja-dic-flatten-tree skkdic-okuri-ari)))))
+          (when entries
+            (nskk-prolog-retract-all 'system-dict-entry 2)
+            (nskk-prolog-set-index 'system-dict-entry 2 :trie)
+            (nskk-prolog-trie-bulk-assert 'system-dict-entry 2 entries)
+            (message "NSKK: Loaded ja-dic system dictionary (%d entries)"
+                     (length entries))
+            'system)))
+    (error
+     (message "NSKK: Could not load ja-dic (%s)"
+              (error-message-string err))
+     nil)))
 
 ;;; Section 5: I/O and lifecycle
 
@@ -466,11 +535,25 @@ Returns a list of readable dictionary file paths."
   "Cached list of okuri-ari consonant character codes.
 Populated by `nskk-dict-initialize' from the `okuri-consonant/1' Prolog table.")
 
+(defun nskk--dict-initialize-system-dictionary ()
+  "Initialize the system dictionary using configured files or built-in ja-dic."
+  (or (when nskk-dict-system-dictionary-files
+        (nskk-dict-load-system-dictionaries))
+      (when (and (null nskk-dict-system-dictionary-files)
+                 nskk-dict-use-ja-dic)
+        (nskk-dict-load-ja-dic))
+      (let ((dict-files (and (null nskk-dict-system-dictionary-files)
+                             (nskk--dict-detect-system-dictionaries))))
+        (when dict-files
+          (let ((nskk-dict-system-dictionary-files dict-files))
+            (nskk-dict-load-system-dictionaries))))))
+
 ;;;###autoload
 (defun nskk-dict-initialize ()
   "Initialize dictionaries by loading system and user dictionaries.
 When `nskk-dict-system-dictionary-files' is nil, auto-detects
-dictionary paths from nix profiles and common system locations.
+ dictionary paths from nix profiles and common system locations.
+NSKK first tries Emacs's built-in `ja-dic' before file auto-detection.
 
 Calling this function interactively allows manual retry: it retracts
 the \\='(dict-initialized) Prolog fact first, then reinitializes."
@@ -485,11 +568,7 @@ the \\='(dict-initialized) Prolog fact first, then reinitializes."
   ;; Populate the module-level cache used by nskk--dict-lookup-okuri-ari
   (setq nskk--dict-okuri-consonants
         (nskk-prolog-query-all-values '(okuri-consonant \?c) '\?c))
-  (let ((dict-files (or nskk-dict-system-dictionary-files
-                        (nskk--dict-detect-system-dictionaries))))
-    (when dict-files
-      (let ((nskk-dict-system-dictionary-files dict-files))
-        (setq nskk--system-dict-index (nskk-dict-load-system-dictionaries)))))
+  (setq nskk--system-dict-index (nskk--dict-initialize-system-dictionary))
   (setq nskk--user-dict-index (nskk-dict-load-user-dictionary))
   ;; Load confirmed dictionary if configured
   (nskk-dict-load-kakutei-dictionary)

--- a/test/nskk-test-framework.el
+++ b/test/nskk-test-framework.el
@@ -50,6 +50,10 @@
 (require 'nskk-input)
 (require 'nskk-converter)
 
+;; Disable loading of large system dictionaries (like ja-dic) by default in
+;; tests. Most unit and integration tests only need small mock dictionaries.
+(setq nskk-dict-use-ja-dic nil)
+
 ;; NOTE: The initialization calls below are guarded by idempotency flags
 ;; (e.g., `nskk--state-prolog-initialized').  If you `eval-buffer' this
 ;; file after editing, those flags will prevent re-initialization unless

--- a/test/unit/nskk-dictionary-test.el
+++ b/test/unit/nskk-dictionary-test.el
@@ -28,6 +28,9 @@
 (require 'nskk-test-macros)
 (require 'nskk-pbt-generators)
 
+(defvar skkdic-okuri-ari nil)
+(defvar skkdic-okuri-nasi nil)
+
 ;;; Section 1: Error type tests
 
 (nskk-describe "module loading"
@@ -391,6 +394,42 @@
         (should result)
         (should (cl-some (lambda (p) (string-match-p "profiles/default" p)) result))))))
 
+(nskk-describe "ja-dic conversion"
+  (nskk-it "decodes and flattens okuri-nasi entries"
+    (let* ((o (- (logand (encode-char ?お 'japanese-jisx0208) #xFF) 32))
+           (sample `(skdic-okuri-nasi
+                     (,o ("緒" "小")))))
+      (should (equal (nskk--dict-ja-dic-flatten-tree sample)
+                     '(("お" . ("小" "緒")))))))
+
+  (nskk-it "decodes and flattens okuri-ari entries"
+    (let* ((wa (- (logand (encode-char ?わ 'japanese-jisx0208) #xFF) 32))
+           (ru (- (logand (encode-char ?る 'japanese-jisx0208) #xFF) 32))
+           (sample `(skkdic-okuri-ari
+                     (,wa t
+                          (,ru t
+                               (-105 ("惡" "悪")))))))
+      (should (equal (nskk--dict-ja-dic-flatten-tree sample)
+                     '(("わるi" . ("悪" "惡")))))))
+
+  (nskk-it "loads flattened ja-dic entries into system-dict-entry"
+    (nskk-prolog-test-with-isolated-db
+      (let* ((o (- (logand (encode-char ?お 'japanese-jisx0208) #xFF) 32))
+             (wa (- (logand (encode-char ?わ 'japanese-jisx0208) #xFF) 32))
+             (ru (- (logand (encode-char ?る 'japanese-jisx0208) #xFF) 32))
+             (skkdic-okuri-nasi `(skdic-okuri-nasi
+                                  (,o ("緒" "小"))))
+             (skkdic-okuri-ari `(skkdic-okuri-ari
+                                 (,wa t
+                                      (,ru t
+                                           (-105 ("惡" "悪")))))))
+        (nskk-with-mocks ((load-library (lambda (_feature) t)))
+          (should (eq 'system (nskk-dict-load-ja-dic)))
+          (should (equal '("小" "緒")
+                         (nskk-prolog-query-value '(system-dict-entry "お" \?c) '\?c)))
+          (should (equal '("悪" "惡")
+                         (nskk-prolog-query-value '(system-dict-entry "わるi" \?c) '\?c))))))))
+
 (nskk-describe "dict-initialize"
   (nskk-it "uses auto-detection when config is nil"
     (let ((nskk-dict-system-dictionary-files nil)
@@ -413,6 +452,22 @@
                         (nskk-dict-load-system-dictionaries (lambda () nil))
                         (nskk-dict-load-user-dictionary (lambda () nil)))
         (nskk-dict-initialize)
+        (should-not detect-called))))
+
+  (nskk-it "prefers ja-dic before file auto-detection"
+    (let ((nskk-dict-system-dictionary-files nil)
+          (nskk-dict-use-ja-dic t)
+          (nskk-dict-user-dictionary-file nil)
+          (nskk--system-dict-index nil)
+          (nskk--user-dict-index nil)
+          (ja-dic-called nil)
+          (detect-called nil))
+      (nskk-with-mocks ((nskk-dict-load-ja-dic (lambda () (setq ja-dic-called t) 'system))
+                        (nskk--dict-detect-system-dictionaries
+                         (lambda () (setq detect-called t) '("/some/path")))
+                        (nskk-dict-load-user-dictionary (lambda () nil)))
+        (nskk-dict-initialize)
+        (should ja-dic-called)
         (should-not detect-called)))))
 
 ;;;


### PR DESCRIPTION


  ## 概要


  Emacsには実はLEIM／KKCというエンジンのために標準でSKK辞書（SKK-JISYO.L相当）が同梱されています。この変更は、
  Emacs 組み込みの ja-dic/ja-dic を利用し、skkdic-okuri-ari / skkdic-okuri-nasi を NSKK のシステム辞書として読み込むようにしました。nskk-dict-system-dictionary-files が未設定の場合は、まず ja-dic を試し、利用できない場合のみ従来の辞書ファイル自動検出へフォールバックします。

  ## 変更内容

  - ja-dic の compact trie 形式を NSKK の (reading . candidates) 形式へ変換する処理を追加
  - skkdic-okuri-nasi と skkdic-okuri-ari の両方を system-dict-entry/2 としてロードする処理を追加
  - システム辞書初期化を整理し、ja-dic を既定の優先経路に変更
  - README にデフォルト辞書の挙動を追記
  - 変換処理・ロード処理・初期化優先順の単体テストを追加

## 意図

  - 外部の SKK 辞書ファイルを明示設定しなくても、Emacs 標準環境だけで NSKK を動かせるようにするため
  - 初期設定の負担を下げつつ、nskk-dict-system-dictionary-files を指定した場合は従来通り明示設定を優先するため