### PR TITLE
refactor: comprehensive quality pass and test expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,103 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ja-dic candidate order**: Removed erroneous `(reverse cands)` in
+  `nskk--dict-ja-dic-flatten-node`.  Candidates stored in the compiled
+  `skkdic-okuri-nasi`/`skkdic-okuri-ari` trees are already in DDSKK-compatible
+  order (as produced by `skkdic-extract-conversion-data`'s cons-reversal of the
+  source text).  Re-reversing them caused nskk to present candidates in the
+  opposite order from DDSKK.  Unit tests updated to document the correct
+  pass-through semantics.
+
 ### Added
 
 - **AZIK y-prefix youon rows**: AZIK mode now supports standard romaji y-prefix
   youon sequences (ky, ry, ny, hy, my, gy, jy, by, py) in addition to the
   existing AZIK-specific g-substitution rows (kg, rg, etc.). AZIK extension
-  keys apply to y-prefix sequences: e.g. `ryp` → りょう, `ryh` → りゅう,
-  `ryz` → りゃん (DDSKK-compatible behavior).
+  keys apply to y-prefix sequences: e.g. `ryp` -> りょう, `ryh` -> りゅう,
+  `ryz` -> りゃん (DDSKK-compatible behavior).
 
 ### Breaking Changes
 
-- **Cursor keys in conversion mode**: C-n/C-p and ââ now commit the current 
-  candidate and move the cursor, instead of navigating candidates. Use SPC/x 
-  for candidate navigation (ddskk-compatible behavior).
-  
-  **Migration**: If you previously used C-n/C-p to navigate candidates, use 
+- **Cursor keys in conversion mode**: C-n/C-p and up/down arrows now commit the
+  current candidate and move the cursor, instead of navigating candidates. Use
+  SPC/x for candidate navigation (ddskk-compatible behavior).
+
+  **Migration**: If you previously used C-n/C-p to navigate candidates, use
   SPC (next candidate) and x (previous candidate) instead.
 
 ### Changed
 
-- C-n/C-p/ââ in converting mode (â¼): Now commits candidate then moves cursor
-  (ddskk-compatible behavior)
+- C-n/C-p/up/down in converting mode (candidate selection): Now commits
+  candidate then moves cursor (ddskk-compatible behavior)
+
+### Code Quality (MELPA preparation)
+
+- **`nskk--compute-phase/text-presence/mode-category` unit tests**: Added 16 unit tests
+  for the three orthogonal feature-dimension helpers in `nskk-keymap.el` covering all
+  return values (converting/henkan-on/idle, has-text/no-text, japanese/marker-mode/other),
+  nil-state guards, priority ordering, and exhaustive-mode sweeps.
+- **`nskk-prolog-trie-has-prefix-p` unit tests**: Added 6 unit tests covering prefix
+  match, exact match (exact key is valid prefix), no-match, no-trie-configured guard,
+  Japanese kana multi-key prefix, and empty-string root invariant.
+
+- **Positive-first `if (not ...)` refactoring**: Converted four CPS guard sites from
+  `(if (not guard) (fail) body)` to `(if guard body (fail))` across `nskk-state.el`
+  (`nskk-state-set/k`), `nskk-henkan.el` (`nskk-core-search/k`), and
+  `nskk-program-dictionary.el` (`nskk-program-dict-lookup/k`,
+  `nskk-program-dict-builtin-lookup/k`).
+- **`(require 'subr-x)` and `(require 'cl-lib)` in `nskk-henkan.el`**: Added missing
+  explicit requires; `string-empty-p` used in 8 sites requires `subr-x`.
+- **`(when (not ...))` → `(unless ...)` in `nskk-henkan.el`**: 1 remaining site converted.
+- **`nskk-converter.el:333` string-empty-p**: Replaced `(zerop (length remaining))` with
+  `(string-empty-p remaining)` — source file consistency.
+
+
+
+- **`string-match-p` for pure boolean matches**: Replaced `(should
+  (string-match ...))` with `(should (string-match-p ...))` in 7 test
+  locations across `nskk-program-dictionary-test.el`, `nskk-henkan-test.el`,
+  and `nskk-okurigana-e2e-test.el` -- avoids clobbering global match data.
+- **`string-empty-p` consistency**: Replaced `(zerop (length ...))` with
+  `string-empty-p` in `nskk-trie.el` (3 sites) and `nskk-converter.el` (2
+  sites); replaced `(> (length str) 0)` with `(not (string-empty-p str))`
+  across 25+ test locations in unit, integration, and E2E test files; replaced
+  list `(> (length list) 0)` guards with bare truthiness checks where
+  appropriate; added `(require 'subr-x)` to both source files.
+- **Hankaku region test strengthened**: Replaced weak `(> (length
+  (buffer-string)) 0)` assertion in `nskk-hankaku-katakana-region` test with
+  exact half-width katakana string check; added 2 additional coverage cases
+  (full aiueo row, ASCII passthrough).
+- **Numeric conversion unit tests**: Added 53 unit tests covering all 8
+  `nskk--numeric-*` functions in `nskk-henkan.el` including type dispatch
+  (#0-#4, unknown), leading-ichi asymmetry in place-value kanji, and
+  multi-pattern template replacement; unit suite 3834 -> 3887.
+- **`nskk-show-mode` unit tests**: Added 15 unit tests for `nskk-show-mode.el`
+  covering `nskk--show-mode-display-inline` overlay/timer lifecycle, exact
+  indicator string content for all 5 modes (hiragana/katakana/ascii/
+  jisx0208-latin/abbrev), `nskk-show-mode-display` deduplication and
+  re-display logic; total suite 3887 -> 5276.
+- **`(should (not (null x)))` simplification**: Simplified double-negation
+  assertions `(should (not (null ...)))` to `(should ...)` in 4 locations
+  across integration test files.
+- **`pcase` refactoring**: Replaced `cond`/`if`-chain dispatches on string/symbol
+  with `pcase` across `nskk-converter.el`, `nskk-prolog.el`, `nskk-context.el`,
+  `nskk-state.el`, `nskk-henkan.el`, `nskk-input.el`, and `nskk-keymap.el`.
+- **Positive-first condition style**: Refactored `(if (not cond) (fail) body)`
+  to `(if cond body (fail))` in `nskk-kana.el` (2 sites), `nskk-server.el`
+  (2 sites), `nskk-keymap.el` (1 site), and `nskk-input.el` (1 site).
+- **`string-empty-p` over `(> (length str) 0)`**: Replaced all length-zero
+  checks with `string-empty-p` in source files; added `(require 'subr-x)` to
+  `nskk-search.el` and `nskk-state.el`.
+- **Explicit `(require 'cl-lib)`**: Added explicit cl-lib requires to
+  `nskk-context.el`, `nskk-henkan.el`, `nskk-isearch.el`, `nskk-kana.el`;
+  removed spurious cl-lib from `nskk-annotation.el`.
+- **`defsubst` for hot path**: Promoted `nskk--conversion-start-active-p` to
+  `defsubst` for inlining in the input dispatch hot path.
+- **`let*`/`let` cleanup**: Collapsed unnecessary `let*` to `let` and removed
+  unused bindings across source and test files.
+- **Zero byte-compile warnings**: All source and test files compile clean.
+- **`:package-version` completeness**: All `defcustom`/`defface` entries carry
+  `:package-version '(nskk . "0.1.0")`.

--- a/README.org
+++ b/README.org
@@ -30,10 +30,10 @@ No external ELPA packages required.
 
 | Component        | Description                             |
 |------------------+-----------------------------------------|
-| Lexical binding  | All 26 modules use =lexical-binding: t= |
+| Lexical binding  | All 25 modules use =lexical-binding: t= |
 | Prolog engine    | Conversion rules as facts/queries       |
 | Layer separation | 7 strict layers, zero circular deps     |
-| Test coverage    | 4,900+ unit/integration/E2E tests       |
+| Test coverage    | 5,000+ unit/integration/E2E tests       |
 
 ** DDSKK Compatibility
 
@@ -233,6 +233,33 @@ stateDiagram-v2
 (add-hook 'nskk-mode-off-hook
           (lambda () (message "NSKK deactivated")))
 #+end_src
+** AZIK Extended Romaji
+#+begin_src elisp
+;; Enable AZIK for more efficient romaji input
+(setopt nskk-converter-romaji-style 'azik)
+
+;; Keyboard layout (us101 or jp106, default: us101)
+(setopt nskk-azik-keyboard-type 'jp106)
+#+end_src
+
+AZIK replaces standard romaji with efficiency shortcuts:
+- =f= → ん hatsuon (e.g. =kf= → かん)
+- =j= → ん hatsuon (e.g. =sj= → さん)
+- Double consonant suffixes → double vowels (e.g. =kk= → きん, =sh= → すう)
+
+** Optional Features
+
+All optional features are auto-loaded when NSKK starts if their modules are present.
+
+| Feature              | Module                 | Enable with                                  |
+|----------------------+------------------------+----------------------------------------------|
+| Annotation display   | =nskk-annotation=      | =(setopt nskk-show-annotation t)=            |
+| Inline mode display  | =nskk-show-mode=       | =(setopt nskk-show-mode-show t)=             |
+| Dynamic dcomp multi  | =nskk-inline=          | =(setopt nskk-dcomp-multiple-activate t)=    |
+| Context auto-mode    | =nskk-context=         | =(nskk-context-global-mode 1)=               |
+| Isearch integration  | =nskk-isearch=         | =(setopt nskk-isearch-enable t)=             |
+| Region operations    | =nskk-region=          | Available as =M-x nskk-region-*= commands   |
+
 ** Customization Group
 #+begin_example
 M-x customize-group RET nskk RET

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,10 +76,10 @@ Key bindings (after nskk-global-mode is enabled):
   C-j              Commit conversion
 
 Useful commands in Emacs:
-  M-x nskk-switch-to-hiragana   Switch to hiragana mode
-  M-x nskk-switch-to-katakana   Switch to katakana mode
-  M-x nskk-switch-to-ascii      Switch to ASCII mode
-  M-x nskk-toggle-kana          Toggle hiragana/katakana
+  M-x nskk-set-mode-hiragana    Switch to hiragana mode
+  M-x nskk-set-mode-katakana    Switch to katakana mode
+  M-x nskk-set-mode-latin       Switch to ASCII/latin mode
+  M-x nskk-set-mode-jisx0208-latin  Switch to full-width latin mode
 
 USAGE_EOF
             '';

--- a/nskk-annotation.el
+++ b/nskk-annotation.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -53,7 +53,7 @@
 
 ;;; Code:
 
-(require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-prolog)
 (require 'nskk-custom)
 (require 'nskk-cps-macros)
@@ -81,6 +81,7 @@ converted candidate during the \u25bc selection phase."
 (defface nskk-annotation-face
   '((t (:inherit font-lock-comment-face :slant italic)))
   "Face for annotation text displayed in the echo area."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-annotation)
 
 ;;;; Buffer-Local State
@@ -148,25 +149,24 @@ area alongside the candidate text.  No-op when `nskk-show-annotation' is nil."
     (let ((annotation (nskk-annotation-lookup reading candidate)))
       (setq nskk--annotation-current annotation)
       (when (and annotation nskk--annotation-visible)
-        (let ((ann-str (nskk--annotation-format annotation)))
-          (when ann-str
-            (let ((message-log-max nil))
-              (message "%s%s" candidate ann-str))))))))
+        (when-let* ((ann-str (nskk--annotation-format annotation)))
+          (let ((message-log-max nil))
+            (message "%s%s" candidate ann-str)))))))
 
 (defun nskk-annotation-clear ()
   "Clear the current annotation state."
   (setq nskk--annotation-current nil))
 
+;;;###autoload
 (defun nskk-annotation-toggle-display ()
   "Toggle visibility of the current candidate annotation.
 When hidden, shows annotation if one is available; when shown, hides it."
   (interactive)
   (setq nskk--annotation-visible (not nskk--annotation-visible))
   (if (and nskk--annotation-visible nskk--annotation-current)
-      (let ((ann-str (nskk--annotation-format nskk--annotation-current)))
-        (when ann-str
-          (let ((message-log-max nil))
-            (message "%s" ann-str))))
+      (when-let* ((ann-str (nskk--annotation-format nskk--annotation-current)))
+        (let ((message-log-max nil))
+          (message "%s" ann-str)))
     (message nil)))
 
 (provide 'nskk-annotation)

--- a/nskk-azik.el
+++ b/nskk-azik.el
@@ -116,6 +116,8 @@ Affects key position-based shortcuts.
 \\='us101 - US 101-key layout"
   :type '(choice (const :tag "Japanese 106-key" jp106)
                  (const :tag "US 101-key" us101))
+  :safe (lambda (v) (memq v '(jp106 us101)))
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-azik)
 
 ;;;; Compile-time Rule Macros
@@ -427,10 +429,11 @@ Performs two passes using azik-key-extends/2 facts:
 Binds @ for jp106 keyboard or [ for us101 keyboard to
 `nskk-toggle-japanese-mode' in `nskk-mode-map'.
 Falls back to `@' for unrecognized keyboard types."
-  (let ((key (or (nskk-prolog-query-value
-                  `(azik-toggle-key ,nskk-azik-keyboard-type \?k) '\?k)
-                 "@")))
-    (keymap-set nskk-mode-map key #'nskk-toggle-japanese-mode)))
+  (when (boundp 'nskk-mode-map)
+    (let ((key (or (nskk-prolog-query-value
+                    `(azik-toggle-key ,nskk-azik-keyboard-type \?k) '\?k)
+                   "@")))
+      (keymap-set nskk-mode-map key #'nskk-toggle-japanese-mode))))
 
 ;;;; Main Initialization
 
@@ -441,15 +444,14 @@ into the azik-rule/2 Prolog predicate.  A bridge rule connects
 azik-rule/2 to romaji-to-kana/2 for unified Prolog queries.
 The hash table is populated from azik-rule/2 for hot-path lookups."
 
-  ;; Step 1: Standard romaji base.
   (nskk--initialize-romaji-table)
 
-  ;; Step 2: Set up azik-rule/2 predicate (index before assert).
+  ;; Set up azik-rule/2 predicate (index before assert).
   (nskk-prolog-retract-all 'azik-rule 2)
   (nskk-prolog-set-index 'azik-rule 2 :hash)
 
-  ;; Step 3: Assert all AZIK rule categories directly as Prolog facts.
-  ;; Prolog is the single source of truth; the hash is a cache (Step 5).
+  ;; Assert all AZIK rule categories directly as Prolog facts.
+  ;; Prolog is the single source of truth; the hash is a read cache.
 
   ;; Special keys: ; → っ (geminate stop), : → ー (prolonged sound).
   (nskk-prolog-deffacts azik-rule
@@ -537,20 +539,19 @@ The hash table is populated from azik-rule/2 for hot-path lookups."
     ("x;" ";") ("kA" "ヵ") ("kE" "ヶ") ("wA" "ヮ")
     ("kyn" "きゃん") ("y<" "←") ("y>" "→") ("y^" "↑"))
 
-  ;; Step 3b: JP106-specific rules (+ → っ for Shift+; key).
+  ;; JP106-specific: + → っ for Shift+; key.
   (when (and (boundp 'nskk-azik-keyboard-type)
              (eq nskk-azik-keyboard-type 'jp106))
     (nskk-prolog-<- (azik-rule "+" "っ")))
 
-  ;; Step 4: Bridge rule — AZIK rules are also romaji-to-kana.
+  ;; Bridge rule — AZIK rules are also romaji-to-kana.
   ;; The variable first arg (?r) is NOT trie-indexed; use azik-rule/2
   ;; directly for enumeration.  Hot-path lookups use the hash cache.
   (nskk-prolog-<- (romaji-to-kana \?r \?k) (azik-rule \?r \?k))
 
-  ;; Step 5: Sync azik-rule/2 → hash table.
   (nskk--azik-sync-to-romaji-hash)
 
-  ;; Step 6: Build Prolog classification predicates from the current hash.
+  ;; Build Prolog classification predicates from the current hash.
   ;;   azik-vowel-char/1   — character codes for a/i/u/e/o (integer facts).
   ;;   azik-key-extends/2  — (PREFIX CH) for every proper prefix in the hash.
   ;;   azik-nonvowel-ext/1 — succeeds when KEY has a non-vowel extension.
@@ -567,17 +568,15 @@ The hash table is populated from azik-rule/2 for hot-path lookups."
     (azik-key-extends \?k \?_ext)
     (not (azik-nonvowel-ext \?k)))
 
-  ;; Step 7: Register :incomplete prefixes + restore standard-romaji semantics.
+  ;; Register :incomplete prefixes + restore standard-romaji semantics.
   ;; Uses azik-key-extends/2 and azik-vowel-shadow/1 queries via Prolog.
   (nskk--azik-finalize-hash-table)
 
-  ;; Step 8: Compound rules added after finalize.
   ;; Inserting after finalize ensures 2-char prefixes like "ka" remain
   ;; complete, enabling sequences like xhkak → しゅうかく.
   (dolist (rule nskk--azik-compound-rules)
     (puthash (car rule) (cadr rule) nskk--romaji-table))
 
-  ;; Step 9: AZIK toggle key binding.
   (nskk--setup-azik-toggle-key))
 
 ;; Register AZIK style

--- a/nskk-cache.el
+++ b/nskk-cache.el
@@ -93,8 +93,9 @@
 
 (defcustom nskk-cache-default-capacity 1000
   "Default cache capacity for LRU/LFU caches."
-  :type 'integer
-  :package-version '("nskk" . "0.1.0")
+  :type 'natnum
+  :safe #'natnump
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-cache)
 
 (defcustom nskk-cache-strategy 'lru
@@ -103,7 +104,8 @@
 \\='lfu means Least Frequently Used."
   :type '(choice (const :tag "LRU" lru)
                  (const :tag "LFU" lfu))
-  :package-version '("nskk" . "0.1.0")
+  :safe (lambda (v) (memq v '(lru lfu)))
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-cache)
 
 ;;; Prolog Facts
@@ -154,10 +156,10 @@
 (defun nskk--cache-type-of (cache)
   "Return the cache type symbol for CACHE.
 Returns the symbol `lru' or `lfu'.  Signals an error for invalid CACHE."
-  (cond
-   ((nskk-cache-lru-p cache) 'lru)
-   ((nskk-cache-lfu-p cache) 'lfu)
-   (t (error "Invalid cache type: %S" cache))))
+  (pcase cache
+    ((pred nskk-cache-lru-p) 'lru)
+    ((pred nskk-cache-lfu-p) 'lfu)
+    (_ (error "Invalid cache type: %S" cache))))
 
 (defmacro nskk-cache-dispatch (cache op &rest args)
   "Dispatch OP on CACHE via the Prolog cache-dispatch-fn/3 table.

--- a/nskk-candidate-window.el
+++ b/nskk-candidate-window.el
@@ -77,6 +77,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-prolog)
 (require 'nskk-custom)
 (require 'nskk-cps-macros)
@@ -112,11 +113,13 @@ Idempotent: safe to call multiple times."
 (defface nskk-candidate-key-face
   '((t (:inherit font-lock-warning-face :weight bold)))
   "Face for candidate selection key labels."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-candidate-window)
 
 (defface nskk-candidate-face
   '((t (:inherit default)))
   "Face for candidate text."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-candidate-window)
 
 (defvar-local nskk--candidate-list-active nil
@@ -214,7 +217,7 @@ selection key or if the resulting index is out of range."
 (defun nskk--candidate-build-tooltip-string (page-candidates)
   "Build tooltip string for PAGE-CANDIDATES.
 Returns a multi-line string with one candidate per line."
-  (mapconcat #'identity page-candidates "\n"))
+  (string-join page-candidates "\n"))
 
 (defun/k nskk-candidate-show-tooltip (candidates current-index)
   "Display CANDIDATES via tooltip starting at CURRENT-INDEX.

--- a/nskk-context.el
+++ b/nskk-context.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -54,6 +54,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'nskk-state)
 (require 'nskk-custom)
 (require 'nskk-cps-macros)
@@ -105,21 +106,18 @@ Used to avoid redundant mode switches when already in ASCII.")
 (defun nskk--context-programming-mode-p ()
   "Return non-nil if context-based switching should apply in the current buffer.
 Checks `nskk-context-programming-mode' against the current major mode."
-  (cond
-   ((eq nskk-context-programming-mode t)
-    (derived-mode-p 'prog-mode))
-   ((listp nskk-context-programming-mode)
-    (apply #'derived-mode-p nskk-context-programming-mode))
-   (t nil)))
+  (pcase nskk-context-programming-mode
+    ('t (derived-mode-p 'prog-mode))
+    ((pred listp) (apply #'derived-mode-p nskk-context-programming-mode))
+    (_ nil)))
 
 (defun nskk--context-in-japanese-context-p ()
   "Return non-nil if point is in a context where Japanese input is appropriate.
 Returns t when inside a string literal, comment, or doc string.
 Uses `syntax-ppss' for O(log n) context detection."
-  (let* ((ppss (syntax-ppss)))
-    (or (nth 3 ppss)   ; inside string
-        (nth 4 ppss)   ; inside comment
-        )))
+  (let ((ppss (syntax-ppss)))
+    (or (nth 3 ppss)    ; inside string
+        (nth 4 ppss)))) ; inside comment
 
 (defun nskk--context-get-current-mode ()
   "Return the current NSKK input mode symbol, or nil if NSKK is not active."

--- a/nskk-converter.el
+++ b/nskk-converter.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -100,6 +100,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-cps-macros)
 (require 'nskk-prolog)
 (require 'nskk-custom)
@@ -243,11 +244,11 @@ Uses the hash table for O(1) exact-match lookups (includes both standard
 and AZIK rules), falling back to the Prolog trie for prefix detection."
   (when (stringp romaji)
     (let ((result (gethash romaji nskk--romaji-table)))
-      (cond
-       ((stringp result) result)
-       ((eq result :incomplete) :incomplete)
-       ((nskk-prolog-trie-has-prefix-p 'romaji-to-kana 2 romaji)
-        :incomplete)))))
+      (pcase result
+        ((pred stringp) result)
+        (':incomplete   :incomplete)
+        (_              (when (nskk-prolog-trie-has-prefix-p 'romaji-to-kana 2 romaji)
+                          :incomplete))))))
 
 (defconst nskk--romaji-char-max 127
   "Maximum ASCII character code accepted as romaji input.
@@ -258,9 +259,8 @@ the sokuon/hatsuon detection logic in `nskk--sokuon-p'.")
   "Convert ROMAJI string to kana by repeatedly applying longest-match conversion.
 Returns converted kana string for string input, nil for nil input."
   (succeed (cond
-             ((null romaji) nil)
              ((not (stringp romaji)) nil)
-             ((zerop (length romaji)) "")
+             ((string-empty-p romaji) "")
              (t (nskk-convert-romaji--internal (downcase romaji))))))
 
 (defun nskk--sokuon-p (c0 remaining)
@@ -330,12 +330,12 @@ Always calls ON-FOUND with the assembled kana string.
 Hand-written explicit pair because ON-FOUND must be passed as a value
 to the recursive call (defun/k only rewrites succeed/fail call forms).
 ON-NOT-FOUND is forwarded unchanged through recursion."
-  (if (or (null remaining) (zerop (length remaining)))
+  (if (or (null remaining) (string-empty-p remaining))
       (funcall on-found (apply #'concat (nreverse parts)))
     (nskk--convert-step/k remaining
       (lambda (kana rest)
         (nskk--convert-loop/k
-         (and (stringp rest) (> (length rest) 0) rest)
+         (and (stringp rest) (not (string-empty-p rest)) rest)
          (cons kana parts)
          on-found on-not-found))
       (lambda (partial)
@@ -365,7 +365,7 @@ proper prefix of a known sequence (no full match yet).
 ON-FAIL is called as (funcall ON-FAIL) when ROMAJI is nil, empty, or has no
 match and is not a known prefix.
 Uses `nskk-converter-lookup' for each candidate prefix length (4 down to 1)."
-  (if (not (and (stringp romaji) (> (length romaji) 0)))
+  (if (or (not (stringp romaji)) (string-empty-p romaji))
       (funcall on-fail)
     (cl-loop for len from (min 4 (length romaji)) downto 1
              for prefix = (substring romaji 0 len)

--- a/nskk-cps-macros.el
+++ b/nskk-cps-macros.el
@@ -103,22 +103,21 @@ as its continuation body and transforms the whole remainder."
   (when forms
     (let ((head (car forms))
           (tail (cdr forms)))
-      (cond
+      (pcase head
        ;; (<- var fn args...) — CPS bind: captures tail as continuation
-       ((and (consp head) (eq (car head) '<-))
+       (`(<- . ,_)
         (list (nskk--cps-transform-<- head tail on-found-sym on-not-found-sym)))
 
        ;; (<-or var fn args... :found f :fail g) — two-arm CPS bind
-       ((and (consp head) (eq (car head) '<-or))
+       (`(<-or . ,_)
         (list (nskk--cps-transform-<-or head on-found-sym on-not-found-sym)))
 
-       ;; More forms follow: head is NOT in tail position, recurse on tail
-       (tail
-        (cons head (nskk--cps-transform-body-list tail on-found-sym on-not-found-sym)))
-
-       ;; head IS the last form (tail position): transform it
-       (t
-        (list (nskk--cps-transform-form head on-found-sym on-not-found-sym)))))))
+       (_
+        (if tail
+            ;; More forms follow: head is NOT in tail position, recurse on tail
+            (cons head (nskk--cps-transform-body-list tail on-found-sym on-not-found-sym))
+          ;; head IS the last form (tail position): transform it
+          (list (nskk--cps-transform-form head on-found-sym on-not-found-sym))))))))
 
 ;;; Internal form dispatch table
 
@@ -181,10 +180,10 @@ Multiple else forms (e.g., (if c t e1 e2)) are wrapped in an implicit progn."
   (let* ((test       (nth 1 form))
          (then       (nth 2 form))
          (else-forms (nthcdr 3 form))
-         (else (cond
-                ((null else-forms)  nil)
-                ((cdr else-forms)   `(progn ,@else-forms))
-                (t                  (car else-forms)))))
+         (else (pcase else-forms
+                ('()       nil)
+                (`(,only)  only)
+                (_         `(progn ,@else-forms)))))
     (if else
         `(if ,test
              ,(nskk--cps-transform-form then on-found-sym on-not-found-sym)
@@ -293,41 +292,39 @@ Emacs Lisp forms are dispatched via `nskk--cps-form-dispatch'.
 Framework pipeline operators (`fail', `succeed', `<-', `<-or', `<-seq')
 are handled inline: they are CPS-specific constructs that have no meaning
 outside `defun/k' bodies."
-  (cond
+  (pcase form
    ;; Atom — pass through unchanged (no CPS transformation possible)
-   ((not (consp form)) form)
+   ((pred (not consp)) form)
 
    ;; (fail) — zero-arity not-found continuation
-   ((eq (car form) 'fail)
-    (if (null (cdr form))
-        `(funcall ,on-not-found-sym)
-       (error "NSKK-CPS: (fail) takes no arguments, got: %S" form)))
+   (`(fail)
+    `(funcall ,on-not-found-sym))
+   (`(fail . ,_)
+    (error "NSKK-CPS: (fail) takes no arguments, got: %S" form))
 
    ;; (succeed VALUE) — one-arity found continuation
-   ((eq (car form) 'succeed)
-    (cond
-     ((null (cdr form))
-       (error "NSKK-CPS: (succeed) requires exactly one argument"))
-     ((cddr form)
-       (error "NSKK-CPS: (succeed) takes exactly one argument, got: %S" form))
-     (t
-      `(funcall ,on-found-sym ,(cadr form)))))
+   (`(succeed)
+    (error "NSKK-CPS: (succeed) requires exactly one argument"))
+   (`(succeed ,val)
+    `(funcall ,on-found-sym ,val))
+   (`(succeed . ,_)
+    (error "NSKK-CPS: (succeed) takes exactly one argument, got: %S" form))
 
    ;; (<- var fn args...) — CPS bind in tail position with no following forms
-   ((eq (car form) '<-)
+   (`(<- . ,_)
     (nskk--cps-transform-<- form nil on-found-sym on-not-found-sym))
 
    ;; (<-or ...) — two-arm CPS bind
-   ((eq (car form) '<-or)
+   (`(<-or . ,_)
     (nskk--cps-transform-<-or form on-found-sym on-not-found-sym))
 
    ;; (<-seq [VAR (FN ARGS...)] BODY...) — sequential CPS bind
-   ((eq (car form) '<-seq)
+   (`(<-seq . ,_)
     (nskk--cps-transform-<-seq form on-found-sym on-not-found-sym))
 
    ;; Dispatch via table, or pass through if the form head is not registered
-   (t
-    (let ((handler (assq (car form) nskk--cps-form-dispatch)))
+   (`(,head . ,_)
+    (let ((handler (assq head nskk--cps-form-dispatch)))
       (if handler
           (funcall (cdr handler) form on-found-sym on-not-found-sym)
         form)))))

--- a/nskk-custom.el
+++ b/nskk-custom.el
@@ -189,6 +189,7 @@ separating the indicator from adjacent mode indicators in the mode line."
     (t (:background "pink")))
   "Cursor color face for hiragana mode.
 The :background attribute is used as the cursor color via `face-attribute'."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-ui)
 
 (defface nskk-cursor-katakana
@@ -196,6 +197,7 @@ The :background attribute is used as the cursor color via `face-attribute'."
     (t (:background "green")))
   "Cursor color face for katakana mode.
 The :background attribute is used as the cursor color via `face-attribute'."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-ui)
 
 (defface nskk-cursor-latin
@@ -203,18 +205,21 @@ The :background attribute is used as the cursor color via `face-attribute'."
     (t (:background "gray")))
   "Cursor color face for ASCII/latin mode.
 The :background attribute is used as the cursor color via `face-attribute'."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-ui)
 
 (defface nskk-cursor-jisx0208-latin
   '((t (:background "gold")))
   "Cursor color face for full-width latin mode.
 The :background attribute is used as the cursor color via `face-attribute'."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-ui)
 
 (defface nskk-cursor-abbrev
   '((t (:background "royalblue")))
   "Cursor color face for abbrev mode.
 The :background attribute is used as the cursor color via `face-attribute'."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-ui)
 
 ;;;; Henkan (Conversion) Settings
@@ -306,21 +311,25 @@ completion candidates appear in the inline list below the preedit."
 (defface nskk-dcomp-face
   '((t (:foreground "DarkKhaki")))
   "Face for the dynamically completed part of the reading (inline suffix)."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dcomp)
 
 (defface nskk-dcomp-multiple-face
   '((t (:inherit default)))
   "Face for candidate readings in the dcomp multiple display."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dcomp)
 
 (defface nskk-dcomp-multiple-trailing-face
   '((t (:foreground "DarkKhaki")))
   "Face for trailing part of candidate readings in dcomp multiple display."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dcomp)
 
 (defface nskk-dcomp-multiple-selected-face
   '((t (:inherit highlight :weight bold)))
   "Face for the currently selected candidate in dcomp multiple display."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dcomp)
 
 ;;;; Kakutei Dictionary Settings

--- a/nskk-dictionary.el
+++ b/nskk-dictionary.el
@@ -7,18 +7,19 @@
 ;; URL: https://github.com/takeokunn/nskk.el
 ;; Version: 0.1.0
 ;; Keywords: i18n
+
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -68,6 +69,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-prolog)
 (require 'nskk-cps-macros)
 
@@ -86,6 +88,7 @@
   "Path to the user dictionary file for storing registered words."
   :type 'file
   :safe #'stringp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
 (defcustom nskk-dict-system-dictionary-files nil
@@ -94,12 +97,14 @@ When nil, NSKK auto-detects dictionary paths from nix profiles
 and common system locations."
   :type '(repeat file)
   :safe (lambda (v) (and (listp v) (cl-every #'stringp v)))
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
 (defcustom nskk-dict-cache-enabled t
   "When non-nil, enable on-disk caching for system dictionaries."
   :type 'boolean
   :safe #'booleanp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
 (defcustom nskk-dict-use-ja-dic t
@@ -107,12 +112,14 @@ and common system locations."
 Only used when `nskk-dict-system-dictionary-files' is nil."
   :type 'boolean
   :safe #'booleanp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
 (defcustom nskk-large-dictionary nil
   "Path to large SKK dictionary file, or nil to disable."
   :type '(choice file (const nil))
   :safe (lambda (v) (or (null v) (stringp v)))
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
 (defvar nskk-jisyo-update-hook nil
@@ -186,8 +193,8 @@ Returns a deduplicated list of candidate strings."
   "Return non-nil if STORED-FILES match current system dictionary configuration.
 Compares sorted STORED-FILES against sorted `nskk-dict-system-dictionary-files'
 so that reordering of dictionary paths does not invalidate the cache."
-  (equal (sort (copy-sequence (or stored-files nil)) #'string<)
-         (sort (copy-sequence (or nskk-dict-system-dictionary-files nil)) #'string<)))
+  (equal (sort (copy-sequence stored-files) #'string<)
+         (sort (copy-sequence nskk-dict-system-dictionary-files) #'string<)))
 
 (defun nskk--dict-run-update-hook ()
   "Run `nskk-jisyo-update-hook' with error protection."
@@ -238,14 +245,18 @@ Returns entry count (0 if no readable files or no entries found)."
                  codes)))
 
 (defun nskk--dict-ja-dic-flatten-node (node prefix)
-  "Recursively flatten ja-dic NODE using PREFIX compact codes."
+  "Recursively flatten ja-dic NODE using PREFIX compact codes.
+Candidates at each leaf are stored in DDSKK-compatible order by
+`skkdic-extract-conversion-data' (which reverses the source text
+order via cons-accumulation).  Using the stored order as-is matches
+DDSKK's candidate presentation order."
   (let* ((code (car node))
          (rest (cdr node))
          (path (append prefix (list code)))
          (cands (car rest))
          (entries nil))
     (when (and (listp cands) (stringp (car cands)))
-      (push (cons (nskk--dict-ja-dic-decode-key path) (reverse cands)) entries)
+      (push (cons (nskk--dict-ja-dic-decode-key path) cands) entries)
       (setq rest (cdr rest)))
     (when (eq (car rest) t) (setq rest (cdr rest)))
     (dolist (child rest)
@@ -291,26 +302,25 @@ When `nskk-show-annotation' is non-nil and nskk-annotation is loaded,
 also registers any candidate annotations found in the line."
   ;; Skip comment lines and empty lines
   (when (and (stringp line)
-             (> (length line) 0)
+             (not (string-empty-p line))
              (not (string-prefix-p ";;" line)))
-    (let ((space-pos (string-search " " line)))
-      (when (and space-pos
-                 (> space-pos 0)
-                 (> (length line) (+ space-pos 2))
-                 (= (aref line (1+ space-pos)) ?/))
-        (let* ((key (substring line 0 space-pos))
-               (candidates-str (substring line (1+ space-pos)))
-               (candidates (nskk--dict-parse-candidates candidates-str)))
-          ;; Register annotations when annotation support is enabled
-          (when (and candidates
-                     (boundp 'nskk-show-annotation)
-                     nskk-show-annotation
-                     (fboundp 'nskk--annotation-load-from-candidates))
-            (let ((with-annots (nskk--dict-parse-candidates-with-annotations
-                                candidates-str)))
-              (nskk--annotation-load-from-candidates key with-annots)))
-          (when candidates
-            (cons key candidates)))))))
+    (when-let* ((space-pos (string-search " " line))
+                ((> space-pos 0))
+                ((> (length line) (+ space-pos 2)))
+                ((= (aref line (1+ space-pos)) ?/)))
+      (let* ((key            (substring line 0 space-pos))
+             (candidates-str (substring line (1+ space-pos)))
+             (candidates     (nskk--dict-parse-candidates candidates-str)))
+        ;; Register annotations when annotation support is enabled
+        (when (and candidates
+                   (boundp 'nskk-show-annotation)
+                   nskk-show-annotation
+                   (fboundp 'nskk--annotation-load-from-candidates))
+          (let ((with-annots (nskk--dict-parse-candidates-with-annotations
+                              candidates-str)))
+            (nskk--annotation-load-from-candidates key with-annots)))
+        (when candidates
+          (cons key candidates))))))
 
 (defun nskk--dict-parse-candidates (str)
   "Parse candidates from STR like \"/candidate1/candidate2/...\"."
@@ -609,7 +619,7 @@ Calls ON-FOUND with candidates when non-empty; ON-NOT-FOUND otherwise."
                                    (nskk--dict-lookup-okuri-ari key)
                                    :test #'equal)
                        okuri-nasi)))
-    (if (and candidates (> (length candidates) 0))
+    (if candidates
         (succeed candidates)
       (fail))))
 
@@ -676,7 +686,7 @@ are empty/invalid or when the Prolog registration query fails."
           (when (and key candidates)
             (insert (format "%s /%s/\n"
                             key
-                            (mapconcat #'identity candidates "/")))))))
+                            (string-join candidates "/")))))))
     (message "NSKK: User dictionary saved to %s"
              nskk-dict-user-dictionary-file)
     (setq nskk-dict-modified nil)))
@@ -707,13 +717,12 @@ Returns \\='kakutei if loaded, nil otherwise."
     (message "NSKK: Loading kakutei dictionary from %s" nskk-kakutei-jisyo)
     (nskk-prolog-retract-all 'kakutei-dict-entry 2)
     (nskk-prolog-set-index 'kakutei-dict-entry 2 :trie)
-    (let ((entries (nskk--dict-parse-file-to-entries nskk-kakutei-jisyo)))
-      (when entries
-        (dolist (entry entries)
-          (nskk-prolog-assert (list (list 'kakutei-dict-entry
-                                         (car entry) (cdr entry)))))
-        (setq nskk--kakutei-dict-loaded t)
-        'kakutei))))
+    (when-let* ((entries (nskk--dict-parse-file-to-entries nskk-kakutei-jisyo)))
+      (dolist (entry entries)
+        (nskk-prolog-assert (list (list 'kakutei-dict-entry
+                                       (car entry) (cdr entry)))))
+      (setq nskk--kakutei-dict-loaded t)
+      'kakutei)))
 
 (defun/k nskk-dict-lookup-kakutei (reading)
   "Look up READING in the confirmed dictionary.

--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -87,6 +87,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+(require 'cl-lib)
 (require 'nskk-cps-macros)
 (require 'nskk-kana)
 (require 'nskk-state)
@@ -360,46 +362,46 @@ immediately so callers receive a definitive result in all cases.
 NOTE: The generated `nskk-core-search/k' variant places ON-FOUND and
 ON-NOT-FOUND after the &optional TYPE and LIMIT parameters.  Callers MUST
 always pass both continuation arguments explicitly."
-  (if (not (stringp key))
-      (fail)
-    (let* ((search-type (or type :exact))
-           (action (nskk-prolog-query-value
-                    `(core-search-type ,search-type ,'\?a) '\?a)))
-      (nskk-debug-log "[HENKAN] search: key=%s type=%s" key (or type 'exact))
-      (pcase action
-        ('dict-lookup
-         ;; Flat fallback chain:
-         ;;   kakutei-dict (confirmed, optional) → local dict → skkserv
-         ;;   → builtin-handlers → program-dict.
-         ;; Kakutei dictionary is checked first: if it returns a single
-         ;; confirmed candidate, it is committed immediately without
-         ;; showing the candidate selection menu.
-         ;; Enable-flag guards live inside each backend's own /k function.
-         ;; fboundp guards in the optional-* wrappers handle unloaded modules.
-         (<-or result nskk--optional-kakutei-lookup key
-           :found (succeed result)
-           :fail  (<-or result2 nskk-dict-lookup key
-             :found (succeed result2)
-             :fail  (<-or r nskk--optional-server-lookup key
-               :found (succeed r)
-               :fail  (<-or b nskk--optional-program-dict-builtin-lookup key
-                 :found (succeed b)
-                 :fail  (<-or p nskk--optional-program-dict-lookup key
-                   :found (succeed p)
-                   :fail  (fail)))))))
-        ('prefix-search
-         (if (nskk-dict-system-index)
-             (<-or r nskk-search-prefix (nskk-dict-system-index) key nil limit
-               :found (succeed r)
-               :fail  (fail))
-           (fail)))
-        ('partial-search
-         (if (nskk-dict-system-index)
-             (<-or r nskk-search-partial (nskk-dict-system-index) key nil limit
-               :found (succeed r)
-               :fail  (fail))
-           (fail)))
-        (_ (signal 'nskk-henkan-unknown-search-type (list search-type)))))))
+  (if (stringp key)
+      (let* ((search-type (or type :exact))
+             (action (nskk-prolog-query-value
+                      `(core-search-type ,search-type ,'\?a) '\?a)))
+        (nskk-debug-log "[HENKAN] search: key=%s type=%s" key (or type 'exact))
+        (pcase action
+          ('dict-lookup
+           ;; Flat fallback chain:
+           ;;   kakutei-dict (confirmed, optional) → local dict → skkserv
+           ;;   → builtin-handlers → program-dict.
+           ;; Kakutei dictionary is checked first: if it returns a single
+           ;; confirmed candidate, it is committed immediately without
+           ;; showing the candidate selection menu.
+           ;; Enable-flag guards live inside each backend's own /k function.
+           ;; fboundp guards in the optional-* wrappers handle unloaded modules.
+           (<-or result nskk--optional-kakutei-lookup key
+             :found (succeed result)
+             :fail  (<-or result2 nskk-dict-lookup key
+               :found (succeed result2)
+               :fail  (<-or r nskk--optional-server-lookup key
+                 :found (succeed r)
+                 :fail  (<-or b nskk--optional-program-dict-builtin-lookup key
+                   :found (succeed b)
+                   :fail  (<-or p nskk--optional-program-dict-lookup key
+                     :found (succeed p)
+                     :fail  (fail)))))))
+          ('prefix-search
+           (if (nskk-dict-system-index)
+               (<-or r nskk-search-prefix (nskk-dict-system-index) key nil limit
+                 :found (succeed r)
+                 :fail  (fail))
+             (fail)))
+          ('partial-search
+           (if (nskk-dict-system-index)
+               (<-or r nskk-search-partial (nskk-dict-system-index) key nil limit
+                 :found (succeed r)
+                 :fail  (fail))
+             (fail)))
+          (_ (signal 'nskk-henkan-unknown-search-type (list search-type)))))
+    (fail)))
 
 ;;;; Henkan Marker Constants
 
@@ -1375,7 +1377,7 @@ The cleanup form guarantees two invariants on exit:
       (unwind-protect
           (let ((entry (read-from-minibuffer
                         (nskk--registration-prompt nskk--registration-depth reading))))
-            (when (not (string-empty-p entry))
+            (unless (string-empty-p entry)
               (setq result entry)
               (nskk-dict-register-word reading entry)))
         (cl-decf nskk--registration-depth)

--- a/nskk-inline.el
+++ b/nskk-inline.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -52,6 +52,7 @@
 
 ;;; Code:
 
+(require 'subr-x)
 (require 'nskk-state)
 (require 'nskk-custom)
 (require 'nskk-cps-macros)
@@ -81,11 +82,13 @@ Possible values:
 (defface nskk-inline-face
   '((t (:inherit shadow :slant italic)))
   "Face for the inline candidate display text."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-inline)
 
 (defface nskk-jisyo-registration-badge-face
   '((t (:inherit font-lock-warning-face :weight bold)))
   "Face for the dictionary registration badge \"↓辞書登録中↓\"."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-inline)
 
 ;;;; Buffer-Local State

--- a/nskk-input.el
+++ b/nskk-input.el
@@ -82,6 +82,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-cps-macros)
 (require 'nskk-henkan)
 (require 'nskk-kana)
@@ -367,18 +368,15 @@ Three arms in priority order:
 Returns non-nil when the sticky-shift action was consumed (arms 1 or 2),
 nil when falling through to self-insert (arm 3)."
   (cond
-   ;; Arm 1 — double semicolon: cancel sticky shift, insert literal ";"
    (nskk--sticky-shift-pending
     (setq nskk--sticky-shift-pending nil)
     (insert ";")
     t)
-   ;; Arm 2 — Japanese mode: arm the sticky-shift pending flag
    ((and nskk-current-state
          (nskk-prolog-holds-p
           `(japanese-mode ,(nskk-state-mode nskk-current-state))))
     (setq nskk--sticky-shift-pending t)
     t)
-   ;; Arm 3 — non-Japanese mode: caller should fall through to self-insert
    (t nil)))
 
 ;;;###autoload
@@ -393,25 +391,18 @@ In standard mode + non-Japanese mode: self-insert (on-not-found path).
   AZIK small-tsu insertion, sticky-shift armed, or sticky-shift cancelled.
 `on-not-found' is called when key is not consumed (self-insert path)."
   :interactive t
-  ;; Outer arm 1 — AZIK style: insert small tsu via romaji processor
-  ;; Outer arm 2 — standard style: delegate to sticky-shift sub-dispatch
-  ;;               (on-found when consumed, on-not-found when non-Japanese)
-  ;; Outer arm 3 — self-insert mode (e.g. abbrev/latin): pass through
   (let* ((style (if (eq nskk-converter-romaji-style 'azik) 'azik 'standard))
          (action (nskk-prolog-query-value
                   `(semicolon-key-action ,style ,'\?action) '\?action)))
     (nskk-debug-log "[INPUT] semicolon-key: style=%s action=%s" style action)
     (pcase action
-      ;; Outer arm 1: AZIK — fire the romaji rule for ";" → っ
       ('insert-small-tsu
        (nskk-process-japanese-input ?\; 1)
        (succeed t))
-      ;; Outer arm 2: standard sticky-shift sub-dispatch
       ('sticky-shift
        (if (nskk--sticky-shift-dispatch)
            (succeed t)
          (fail)))
-      ;; Outer arm 3: explicit self-insert (latin/abbrev style routes here)
       ('self-insert
        (nskk-self-insert 1)
        (fail))
@@ -772,10 +763,10 @@ NEW-BUFFER-VALUE is the string to leave in the buffer after emission
   (let* ((prefix-without-n
           (substring nskk--romaji-buffer 0 (1- (length nskk--romaji-buffer))))
          (prefix-kana
-          (if (> (length prefix-without-n) 0)
-              (let ((prev (nskk-converter-convert prefix-without-n)))
-                (if (and prev (stringp (car prev))) (car prev) ""))
-            "")))
+          (if (string-empty-p prefix-without-n)
+              ""
+            (let ((prev (nskk-converter-convert prefix-without-n)))
+              (if (and prev (stringp (car prev))) (car prev) "")))))
     (setq nskk--romaji-buffer new-buffer-value)
     (succeed (concat prefix-kana "\u3093"))))
 
@@ -784,10 +775,10 @@ NEW-BUFFER-VALUE is the string to leave in the buffer after emission
 Returns `match' when RESULT is a cons with a string car,
 `incomplete' when RESULT is a cons with :incomplete car,
 or `no-result' otherwise."
-  (cond
-   ((and (consp result) (stringp (car result))) 'match)
-   ((and (consp result) (eq (car result) :incomplete)) 'incomplete)
-   (t 'no-result)))
+  (pcase result
+    (`(,(pred stringp) . ,_) 'match)
+    (`(:incomplete . ,_)     'incomplete)
+    (_                       'no-result)))
 
 (defvar nskk--romaji-classify-cache
   (make-hash-table :test 'equal :size 16)
@@ -1026,7 +1017,7 @@ with KANA."
         (remaining (cdr result)))
     (nskk-debug-log "[INPUT] romaji-converted: kana=%s" kana)
     (setq nskk--romaji-buffer
-          (if (and (stringp remaining) (> (length remaining) 0)) remaining ""))
+          (if (and (stringp remaining) (not (string-empty-p remaining))) remaining ""))
     (succeed kana)))
 
 (defun/k nskk--kana-handle-n-consonant (char result)

--- a/nskk-isearch.el
+++ b/nskk-isearch.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -54,6 +54,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'isearch)
 (require 'nskk-state)
 (require 'nskk-custom)
@@ -86,6 +87,7 @@ The isearch prompt shows the current NSKK mode indicator."
   "Alist mapping NSKK mode symbols to isearch prompt strings.
 Used to show the current input mode in the isearch prompt."
   :type '(alist :key-type symbol :value-type string)
+  :safe (lambda (v) (and (listp v) (cl-every (lambda (e) (and (consp e) (symbolp (car e)) (stringp (cdr e)))) v)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-isearch)
 
@@ -131,6 +133,7 @@ ORIG-FUN is the original `isearch-message-prefix' function."
 
 ;;;; Setup/Teardown
 
+;;;###autoload
 (defun nskk-isearch-setup ()
   "Install NSKK isearch integration.
 Adds hooks and advice to enable Japanese isearch."
@@ -138,6 +141,7 @@ Adds hooks and advice to enable Japanese isearch."
   (add-hook 'isearch-mode-end-hook #'nskk--isearch-teardown)
   (advice-add 'isearch-message-prefix :around #'nskk--isearch-prompt-advice))
 
+;;;###autoload
 (defun nskk-isearch-teardown ()
   "Remove NSKK isearch integration."
   (remove-hook 'isearch-mode-hook #'nskk--isearch-setup)

--- a/nskk-kana.el
+++ b/nskk-kana.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -101,6 +101,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'nskk-prolog)
 (require 'nskk-cps-macros)
 
@@ -365,12 +366,12 @@ round-trip (~10µs per query).  Prolog facts remain authoritative for
 cross-module queries; the hash table is the hot-path cache.
 Succeeds with the converted string if STRING is a string.
 Fails if STRING is not a string."
-  (if (not (stringp string))
-      (fail)
-    (succeed (cl-loop for char across string
-                      for str = (char-to-string char)
-                      concat (or (gethash str nskk--kana-zenkaku-to-hankaku-table)
-                                 str)))))
+  (if (stringp string)
+      (succeed (cl-loop for char across string
+                        for str = (char-to-string char)
+                        concat (or (gethash str nskk--kana-zenkaku-to-hankaku-table)
+                                   str)))
+    (fail)))
 
 (defun/k nskk-kana-zenkaku-to-hankaku (string-or-char)
   "Convert zenkaku katakana STRING-OR-CHAR to hankaku.
@@ -380,15 +381,14 @@ the hankaku string equivalent, or a one-character string if unrecognized.
 For any other type, returns STRING-OR-CHAR unchanged.
 Uses direct hash lookup instead of Prolog round-trip for hot-path speed.
 Always succeeds."
-  (cond
-   ((stringp string-or-char)
-    (<- result nskk--kana-zenkaku-string-to-hankaku string-or-char)
-    (succeed result))
-   ((integerp string-or-char)
-    (let* ((str (char-to-string string-or-char)))
-      (succeed (or (gethash str nskk--kana-zenkaku-to-hankaku-table) str))))
-   (t
-    (succeed string-or-char))))
+  (pcase string-or-char
+    ((pred stringp)
+     (<- result nskk--kana-zenkaku-string-to-hankaku string-or-char)
+     (succeed result))
+    ((pred integerp)
+     (let ((str (char-to-string string-or-char)))
+       (succeed (or (gethash str nskk--kana-zenkaku-to-hankaku-table) str))))
+    (_ (succeed string-or-char))))
 
 (defun nskk--kana-hankaku-lookup-at (string i len)
   "Look up hankaku->zenkaku conversion at position I in STRING (length LEN).
@@ -411,14 +411,14 @@ Tries two-character sequences first to handle dakuten combinations.
 Uses direct hash table lookup instead of Prolog round-trip.
 Succeeds with the converted string if STRING is a string.
 Fails if STRING is not a string."
-  (if (not (stringp string))
-      (fail)
-    (let ((parts nil) (i 0) (len (length string)))
-      (while (< i len)
-        (let ((pair (nskk--kana-hankaku-lookup-at string i len)))
-          (push (car pair) parts)
-          (setq i (+ i (cdr pair)))))
-      (succeed (apply #'concat (nreverse parts))))))
+  (if (stringp string)
+      (let ((parts nil) (i 0) (len (length string)))
+        (while (< i len)
+          (let ((pair (nskk--kana-hankaku-lookup-at string i len)))
+            (push (car pair) parts)
+            (setq i (+ i (cdr pair)))))
+        (succeed (apply #'concat (nreverse parts))))
+    (fail)))
 
 (defun/k nskk-kana-hankaku-to-zenkaku (string-or-char)
   "Convert hankaku katakana STRING-OR-CHAR to zenkaku.
@@ -427,15 +427,14 @@ Unrecognized characters are passed through unchanged.
 Uses direct hash table lookup instead of Prolog round-trip.
 For any other type, returns STRING-OR-CHAR unchanged.
 Always succeeds."
-  (cond
-   ((stringp string-or-char)
-    (<- result nskk--kana-hankaku-string-to-zenkaku string-or-char)
-    (succeed result))
-   ((integerp string-or-char)
-    (let* ((str (char-to-string string-or-char)))
-      (succeed (or (gethash str nskk--kana-hankaku-to-zenkaku-table) str))))
-   (t
-    (succeed string-or-char))))
+  (pcase string-or-char
+    ((pred stringp)
+     (<- result nskk--kana-hankaku-string-to-zenkaku string-or-char)
+     (succeed result))
+    ((pred integerp)
+     (let ((str (char-to-string string-or-char)))
+       (succeed (or (gethash str nskk--kana-hankaku-to-zenkaku-table) str))))
+    (_ (succeed string-or-char))))
 
 ;;;; Prolog Facts Initialization
 

--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -95,6 +95,7 @@
 
 ;;; Code:
 
+(require 'subr-x)
 (require 'nskk-state)
 (require 'nskk-prolog)
 (require 'nskk-cps-macros)
@@ -305,10 +306,11 @@ Uses `nskk-converting-p' for converting detection (matches
   "Return the current mode category: `japanese', `marker-mode', or `other'.
 Queries `mode-category/2' to map the current input mode to a category.
 Returns `other' when no state exists."
-  (if (not nskk-current-state) 'other
-    (or (nskk-prolog-query-value
-         `(mode-category ,(nskk-state-mode nskk-current-state) \?c) '\?c)
-        'other)))
+  (if nskk-current-state
+      (or (nskk-prolog-query-value
+           `(mode-category ,(nskk-state-mode nskk-current-state) \?c) '\?c)
+          'other)
+    'other))
 
 (defun nskk--classify-state ()
   "Return a rich state classification symbol for the current NSKK state.

--- a/nskk-modeline.el
+++ b/nskk-modeline.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -202,7 +202,7 @@ is unbound."
              nskk-current-state)
     (when-let* ((mode (nskk-state-mode nskk-current-state))
                 (color (nskk--cursor-with-color mode)))
-      (when (not (equal color nskk--last-cursor-color))
+      (unless (equal color nskk--last-cursor-color)
         (set-cursor-color color)
         (setq nskk--last-cursor-color color)))))
 

--- a/nskk-program-dictionary.el
+++ b/nskk-program-dictionary.el
@@ -375,15 +375,15 @@ calls on-found.
 
 Calls on-found with the merged, deduplicated candidate list; on-not-found
 when disabled, `nskk-program-dicts' is nil, or all entries miss."
-  (if (not (and nskk-program-dict-enable nskk-program-dicts))
-      (fail)
-    (let ((cache (nskk--program-dict-ensure-cache)))
-      (<-or cached nskk-cache-get cache key
-        :found (succeed cached)
-        :fail  (progn
-                 (<- results nskk--program-dict-collect-all nskk-program-dicts key)
-                 (nskk-cache-put cache key results)
-                 (succeed results))))))
+  (if (and nskk-program-dict-enable nskk-program-dicts)
+      (let ((cache (nskk--program-dict-ensure-cache)))
+        (<-or cached nskk-cache-get cache key
+          :found (succeed cached)
+          :fail  (progn
+                   (<- results nskk--program-dict-collect-all nskk-program-dicts key)
+                   (nskk-cache-put cache key results)
+                   (succeed results))))
+    (fail)))
 
 ;;; Section 13: Built-in dispatch table
 
@@ -496,24 +496,24 @@ Handler errors are caught via `condition-case', logged via
 Calls on-found with the candidate list when at least one handler returns
 results; calls on-not-found when disabled, KEY is not a string, or no
 handler produces candidates."
-  (if (not (and (stringp key) nskk-program-dict-enable))
-      (fail)
-    (let (results)
-      (dolist (pair nskk-program-dict-dispatch-table)
-        (when (string-prefix-p (car pair) key)
-          (let ((cands (condition-case err
-                           (funcall (cdr pair) key)
-                         (error
-                          (nskk-debug-message
-                           "nskk-program-dict: builtin handler [%s] error: %s"
-                           (car pair) (error-message-string err))
-                          nil))))
-            (when (consp cands)
-              (setq results (append results cands))))))
-      (if results
-          (succeed (mapcar (lambda (c) (propertize c 'nskk-no-learn t))
-                           (delete-dups (copy-sequence results))))
-        (fail)))))
+  (if (and (stringp key) nskk-program-dict-enable)
+      (let (results)
+        (dolist (pair nskk-program-dict-dispatch-table)
+          (when (string-prefix-p (car pair) key)
+            (let ((cands (condition-case err
+                             (funcall (cdr pair) key)
+                           (error
+                            (nskk-debug-message
+                             "nskk-program-dict: builtin handler [%s] error: %s"
+                             (car pair) (error-message-string err))
+                            nil))))
+              (when (consp cands)
+                (setq results (append results cands))))))
+        (if results
+            (succeed (mapcar (lambda (c) (propertize c 'nskk-no-learn t))
+                             (delete-dups (copy-sequence results))))
+          (fail)))
+    (fail)))
 
 (provide 'nskk-program-dictionary)
 

--- a/nskk-prolog.el
+++ b/nskk-prolog.el
@@ -125,7 +125,7 @@
 
 ;;;; Variable Representation
 
-(defun nskk-prolog-variable-p (x)
+(defsubst nskk-prolog-variable-p (x)
   "Return non-nil if X is a Prolog variable.
 Prolog variables are symbols whose name starts with `?'
 \(e.g., \\='\\?x, \\='\\?char, \\='\\?_).
@@ -343,18 +343,18 @@ form `?_anon_N' using a fresh increment of `nskk--prolog-var-counter',
 independent of COUNTER.  Non-variable atoms and numbers are returned
 unchanged.
 Returns the renamed term."
-  (cond
-   ((nskk--prolog-anonymous-p term)
-    (intern (format "?_anon_%d" (cl-incf nskk--prolog-var-counter))))
-   ((nskk-prolog-variable-p term)
-    (or (gethash term mapping)
-        (let ((fresh (intern (format "%s_%d" (symbol-name term) counter))))
-          (puthash term fresh mapping)
-          fresh)))
-   ((consp term)
-    (cons (nskk--prolog-rename-term (car term) counter mapping)
-          (nskk--prolog-rename-term (cdr term) counter mapping)))
-   (t term)))
+  (pcase term
+    ((pred nskk--prolog-anonymous-p)
+     (intern (format "?_anon_%d" (cl-incf nskk--prolog-var-counter))))
+    ((pred nskk-prolog-variable-p)
+     (or (gethash term mapping)
+         (let ((fresh (intern (format "%s_%d" (symbol-name term) counter))))
+           (puthash term fresh mapping)
+           fresh)))
+    (`(,h . ,tl)
+     (cons (nskk--prolog-rename-term h counter mapping)
+           (nskk--prolog-rename-term tl counter mapping)))
+    (_ term)))
 
 (defun nskk--prolog-rename-variables (clause counter)
   "Rename all variables in CLAUSE using COUNTER suffix.
@@ -374,38 +374,40 @@ This set is intentionally closed; all arithmetic needed by NSKK is covered.")
   "Evaluate arithmetic EXPR under SUBST, returning a number.
 EXPR may be a number, a bound Prolog variable, or a list (OP A B)
 where OP is one of +, -, *, / and A, B are arithmetic expressions."
-  (cond
-   ((numberp expr) expr)
-   ((nskk-prolog-variable-p expr)
-    (let ((val (nskk-prolog-walk expr subst)))
-      (if (eq val expr)
-          (error "Unbound variable in arithmetic: %S" expr)
-        (nskk--prolog-eval-arith val subst))))
-   ;; Emacs Lisp bound symbol (e.g., defconst values used in rule bodies)
-   ((and (symbolp expr) (not (nskk-prolog-variable-p expr)) (boundp expr))
-    (nskk--prolog-eval-arith (symbol-value expr) subst))
-   ((consp expr)
-    (let* ((op (car expr))
-           (fn (cdr (assq op nskk--prolog-arith-operators)))
-           (a (nskk--prolog-eval-arith (cadr expr) subst))
-           (b (nskk--prolog-eval-arith (caddr expr) subst)))
-      (if fn
-          (funcall fn a b)
-        (error "Unknown arithmetic operator: %S" op))))
-   (t (error "Cannot evaluate arithmetic expression: %S" expr))))
+  (pcase expr
+    ((pred numberp) expr)
+    ((pred nskk-prolog-variable-p)
+     (let ((val (nskk-prolog-walk expr subst)))
+       (if (eq val expr)
+           (error "Unbound variable in arithmetic: %S" expr)
+         (nskk--prolog-eval-arith val subst))))
+    ;; Emacs Lisp bound symbol (e.g., defconst values used in rule bodies).
+    ;; The nskk-prolog-variable-p branch above already handles Prolog ?vars,
+    ;; so no redundant (not (nskk-prolog-variable-p expr)) guard is needed.
+    ((and (pred symbolp) (guard (boundp expr)))
+     (nskk--prolog-eval-arith (symbol-value expr) subst))
+    ((pred consp)
+     (let* ((op (car expr))
+            (fn (cdr (assq op nskk--prolog-arith-operators)))
+            (a (nskk--prolog-eval-arith (cadr expr) subst))
+            (b (nskk--prolog-eval-arith (caddr expr) subst)))
+       (if fn
+           (funcall fn a b)
+         (error "Unknown arithmetic operator: %S" op))))
+    (_ (error "Cannot evaluate arithmetic expression: %S" expr))))
 
 ;;;; Built-in Goal Handlers
 
 (defun nskk--prolog-goal-kind (goal)
   "Classify GOAL into a dispatch key for `nskk--prolog-builtin-table'."
-  (cond
-   ((eq goal '!)                            :cut)
-   ((not (consp goal))                     :normal)
-   ((eq (car goal) 'not)                   :not)
-   ((eq (car goal) 'assertz)               :assertz)
-   ((eq (car goal) 'retract)               :retract)
-   ((memq (car goal) '(is =:= > < >= <=)) :arith)
-   (t                                      :normal)))
+  (pcase goal
+    ('!                                    :cut)
+    ((pred (not consp))                    :normal)
+    (`(not      . ,_)                      :not)
+    (`(assertz  . ,_)                      :assertz)
+    (`(retract  . ,_)                      :retract)
+    (`(,(or 'is '=:= '> '< '>= '<=) . ,_) :arith)
+    (_                                     :normal)))
 
 (defun nskk--prolog-handle-cut (_goal rest subst k)
   "Handle cut (!): commit to current clause, abort remaining alternatives.
@@ -782,27 +784,25 @@ this function returns bindings from ALL solutions."
 (defun nskk-prolog-ground-p (term)
   "Return non-nil if TERM has no unbound Prolog variables.
 A ground term is fully instantiated with no unbound variables."
-  (cond
-   ((nskk-prolog-variable-p term) nil)
-   ((consp term)
-    (and (nskk-prolog-ground-p (car term))
-         (nskk-prolog-ground-p (cdr term))))
-   (t t)))
+  (pcase term
+    ((pred nskk-prolog-variable-p) nil)
+    (`(,h . ,tl) (and (nskk-prolog-ground-p h) (nskk-prolog-ground-p tl)))
+    (_ t)))
 
 (defun nskk-prolog-substitute (term subst)
   "Apply substitution SUBST to TERM, replacing all bound variables.
 Walks each variable to its final binding and reconstructs the term.
 Unbound variables remain as-is in the result."
-  (cond
-   ((nskk-prolog-variable-p term)
-    (let ((walked (nskk-prolog-walk term subst)))
-      (if (nskk-prolog-variable-p walked)
-          walked
-        (nskk-prolog-substitute walked subst))))
-   ((consp term)
-    (cons (nskk-prolog-substitute (car term) subst)
-          (nskk-prolog-substitute (cdr term) subst)))
-   (t term)))
+  (pcase term
+    ((pred nskk-prolog-variable-p)
+     (let ((walked (nskk-prolog-walk term subst)))
+       (if (nskk-prolog-variable-p walked)
+           walked
+         (nskk-prolog-substitute walked subst))))
+    (`(,h . ,tl)
+     (cons (nskk-prolog-substitute h subst)
+           (nskk-prolog-substitute tl subst)))
+    (_ term)))
 
 (defun nskk-prolog-trie-prefix-search (predicate arity prefix)
   "Search PREDICATE/ARITY trie for keys starting with PREFIX.
@@ -869,7 +869,7 @@ Example:
   (nskk-prolog-holds-p \\='(dict-initialized))
   ;; => t   (when the fact is asserted)
   ;; => nil (when the fact is absent)"
-  (not (null (nskk-prolog-query-one goal))))
+  (and (nskk-prolog-query-one goal) t))
 
 ;;;; DSL Macros
 

--- a/nskk-region.el
+++ b/nskk-region.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -78,7 +78,7 @@ Returns a string of the converted character."
 
 (defun nskk--string-ascii-to-zenkaku (str)
   "Convert all ASCII printable characters in STR to full-width equivalents."
-  (apply #'concat (mapcar #'nskk--ascii-char-to-zenkaku (string-to-list str))))
+  (mapconcat #'nskk--ascii-char-to-zenkaku str ""))
 
 (defun nskk--zenkaku-char-to-ascii (char)
   "Convert full-width Unicode CHAR to ASCII equivalent.
@@ -96,7 +96,7 @@ Returns a string of the converted character."
 
 (defun nskk--string-zenkaku-to-ascii (str)
   "Convert all full-width ASCII variants in STR to basic ASCII equivalents."
-  (apply #'concat (mapcar #'nskk--zenkaku-char-to-ascii (string-to-list str))))
+  (mapconcat #'nskk--zenkaku-char-to-ascii str ""))
 
 ;;;; Public Commands
 

--- a/nskk-search.el
+++ b/nskk-search.el
@@ -84,6 +84,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-cps-macros)
 (require 'nskk-dictionary)
 (require 'nskk-cache)
@@ -180,7 +181,7 @@ arguments explicitly; omitting them causes a silent nil-continuation crash,
 because Emacs Lisp `&optional' applies to all parameters after the first."
   (unless (nskk-dict-index-p index)
     (signal 'nskk-dict-search-invalid-index (list index)))
-  (unless (and (stringp query) (> (length query) 0))
+  (unless (and (stringp query) (not (string-empty-p query)))
     (signal 'nskk-dict-search-invalid-query (list query)))
 
   ;; Default search type
@@ -229,7 +230,7 @@ The /k variant calls ON-FOUND with the entry, ON-NOT-FOUND otherwise."
                         `(,pred ,query \?candidates) '\?candidates)))
          (entry      (when candidates
                        (make-nskk-dict-entry :key query :candidates candidates))))
-    (nskk-debug-log "[SEARCH] exact: query=%s found=%s" query (if candidates t nil))
+    (nskk-debug-log "[SEARCH] exact: query=%s found=%s" query (and candidates t))
     (if (and entry
              (nskk--search-match-okuri-type-p okuri-type (nskk-dict-entry-okuri entry)))
         (succeed entry)
@@ -435,12 +436,10 @@ the integer Levenshtein distance from QUERY."
 
 (defun nskk--search-candidate-word (candidate)
   "Extract the word string from CANDIDATE."
-  (cond
-   ((stringp candidate) candidate)
-   ((and (consp candidate)
-         (stringp (car candidate)))
-    (car candidate))
-   (t nil)))
+  (pcase candidate
+    ((pred stringp) candidate)
+    (`(,(pred stringp) . ,_) (car candidate))
+    (_ nil)))
 
 
 ;;; Learning data management

--- a/nskk-server.el
+++ b/nskk-server.el
@@ -83,6 +83,7 @@
 
 ;;; Code:
 
+(require 'subr-x)
 (require 'nskk-custom)
 (require 'nskk-prolog)
 (require 'nskk-cps-macros)
@@ -109,6 +110,7 @@ To enable skkserv lookup:
   (setq nskk-server-portnum 1178)"
   :type 'boolean
   :safe #'booleanp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
 (defcustom nskk-server-host "localhost"
@@ -117,13 +119,15 @@ Only used when `nskk-server-enable' is non-nil.
 Note: connections to non-localhost hosts are unencrypted plaintext TCP."
   :type 'string
   :safe #'stringp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
 (defcustom nskk-server-portnum 1178
   "TCP port number of the skkserv instance.
 The default port 1178 is registered as \\='skkserv\\=' in /etc/services."
-  :type 'integer
-  :safe #'integerp
+  :type 'natnum
+  :safe #'natnump
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
 (defcustom nskk-server-coding-system 'euc-jp
@@ -132,6 +136,7 @@ Traditional skkserv implementations use EUC-JP.  Modern servers such as
 yaskkserv2 may use UTF-8; set this to \\='utf-8 in that case."
   :type 'coding-system
   :safe #'coding-system-p
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
 (defcustom nskk-server-timeout 1
@@ -143,6 +148,7 @@ Note: enabling skkserv may exceed the package's < 10ms search latency
 target when the server is remote or slow."
   :type 'number
   :safe #'numberp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
 (defcustom nskk-server-report-response nil
@@ -151,6 +157,7 @@ Useful for diagnosing latency issues.  Requires `nskk-debug-enabled' to
 be non-nil for the log entries to appear."
   :type 'boolean
   :safe #'booleanp
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
 ;;;; Internal State
@@ -232,14 +239,14 @@ Connects to `nskk-server-host':`nskk-server-portnum'.  On success,
 calls `nskk--server-configure-process' to set up the connection and
 update Prolog state, then succeeds with the process object.
 Returns nil (via sync wrapper) or fails if disabled or connection fails."
-  (if (not nskk-server-enable)
-      (fail)
-    (let ((proc (nskk--server-make-connection)))
-      (if proc
-          (progn
-            (nskk--server-configure-process proc)
-            (succeed proc))
-        (fail)))))
+  (if nskk-server-enable
+      (let ((proc (nskk--server-make-connection)))
+        (if proc
+            (progn
+              (nskk--server-configure-process proc)
+              (succeed proc))
+          (fail)))
+    (fail)))
 
 (defun/done nskk-server-close ()
   "Send disconnect command to skkserv and clean up the connection.
@@ -264,13 +271,13 @@ Succeeds with t if the connection is live after this call.
 Fails immediately when `nskk-server-enable' is nil.
 Fails when `nskk-server-enable' is non-nil but the connection cannot
 be established."
-  (if (not nskk-server-enable)
-      (fail)
-    (if (nskk-server-live-p)
-        (succeed t)
-      (nskk-debug-message "nskk-server-ensure-open: reconnecting...")
-      (<- _open-proc nskk-server-open)
-      (succeed t))))
+  (if nskk-server-enable
+      (if (nskk-server-live-p)
+          (succeed t)
+        (nskk-debug-message "nskk-server-ensure-open: reconnecting...")
+        (<- _open-proc nskk-server-open)
+        (succeed t))
+    (fail)))
 
 ;;;; Protocol Implementation
 
@@ -282,7 +289,7 @@ characters (which would cause protocol desync).
 Then chains to `nskk-server-live-p/k' for connection liveness."
   (if (and nskk-server-enable
            (stringp key)
-           (> (length key) 0)
+           (not (string-empty-p key))
            (not (string-match-p "[\x00-\x1F\x7F ]" key)))
       (<- live-check nskk-server-live-p)
     (fail)))
@@ -306,7 +313,7 @@ Strips annotations (\\\"word;note\\\" -> \\\"word\\\") via
 Succeeds with the candidate list when at least one candidate is found.
 Fails for not-found responses, empty responses, or non-string inputs."
   (if (and (stringp response)
-           (> (length response) 0)
+           (not (string-empty-p response))
            (nskk-prolog-holds-p
             `(server-response-type ,(substring response 0 1) found)))
       (let* ((body  (string-trim-right (substring response 1) "[\r\n]+"))
@@ -315,7 +322,7 @@ Fails for not-found responses, empty responses, or non-string inputs."
               (delq nil
                     (mapcar (lambda (s)
                               (let ((trimmed (string-trim s)))
-                                (when (> (length trimmed) 0)
+                                (unless (string-empty-p trimmed)
                                   (nskk--server-strip-annotation trimmed))))
                             parts))))
         (if candidates (succeed candidates) (fail)))

--- a/nskk-show-mode.el
+++ b/nskk-show-mode.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -84,6 +84,7 @@ for a short duration then disappears automatically."
 (defface nskk-show-mode-inline-face
   '((t (:inherit font-lock-keyword-face :weight bold)))
   "Face for the inline mode indicator text."
+  :package-version '(nskk . "0.1.0")
   :group 'nskk-show-mode)
 
 ;;;; Buffer-Local State
@@ -145,17 +146,12 @@ Safe to call when overlay and timer are nil."
 
 (defun nskk--show-mode-display-tooltip (indicator-str)
   "Display INDICATOR-STR using the Emacs tooltip API (GUI only)."
-  (when (display-graphic-p)
-    (let ((pos (posn-at-point)))
-      (when pos
-        (tooltip-show indicator-str)
-        ;; Schedule tooltip hide
-        (let ((nskk--show-mode-timer-local nskk--show-mode-timer))
-          (when (timerp nskk--show-mode-timer-local)
-            (cancel-timer nskk--show-mode-timer-local))
-          (setq nskk--show-mode-timer
-                (run-with-timer nskk-show-mode-duration nil
-                                #'tooltip-hide)))))))
+  (when (and (display-graphic-p) (posn-at-point))
+    (tooltip-show indicator-str)
+    (when (timerp nskk--show-mode-timer)
+      (cancel-timer nskk--show-mode-timer))
+    (setq nskk--show-mode-timer
+          (run-with-timer nskk-show-mode-duration nil #'tooltip-hide))))
 
 ;;;; Public API
 

--- a/nskk-state.el
+++ b/nskk-state.el
@@ -283,25 +283,25 @@ Routes \\='mode and \\='henkan-phase through validated setters; all other slots
 are set directly via `setf'.
 Sync wrapper returns VALUE, or nil when STATE is invalid or KEY is unknown.
 The /k variant calls ON-FOUND with VALUE on success, ON-NOT-FOUND otherwise."
-  (if (not (nskk-state-p state))
-      (fail)
-    (let ((key-sym (if (stringp key) (intern key) key)))
-      (let ((result
-             (pcase key-sym
-               ('mode         (nskk-state-set-mode state value))
-               ('henkan-phase (nskk-state-set-henkan-phase state value))
-               ('input-buffer     (setf (nskk-state-input-buffer     state) value) value)
-               ('converted-buffer (setf (nskk-state-converted-buffer state) value) value)
-               ('candidates       (setf (nskk-state-candidates       state) value) value)
-               ('current-index    (setf (nskk-state-current-index    state) value) value)
-               ('henkan-position  (setf (nskk-state-henkan-position  state) value) value)
-               ('marker-position  (setf (nskk-state-marker-position  state) value) value)
-               ('previous-mode    (setf (nskk-state-previous-mode    state) value) value)
-               ('undo-stack       (setf (nskk-state-undo-stack       state) value) value)
-               ('redo-stack       (setf (nskk-state-redo-stack       state) value) value)
-               ('metadata         (setf (nskk-state-metadata         state) value) value)
-               (_ nil))))
-        (if result (succeed result) (fail))))))
+  (if (nskk-state-p state)
+      (let ((key-sym (if (stringp key) (intern key) key)))
+        (let ((result
+               (pcase key-sym
+                 ('mode         (nskk-state-set-mode state value))
+                 ('henkan-phase (nskk-state-set-henkan-phase state value))
+                 ('input-buffer     (setf (nskk-state-input-buffer     state) value) value)
+                 ('converted-buffer (setf (nskk-state-converted-buffer state) value) value)
+                 ('candidates       (setf (nskk-state-candidates       state) value) value)
+                 ('current-index    (setf (nskk-state-current-index    state) value) value)
+                 ('henkan-position  (setf (nskk-state-henkan-position  state) value) value)
+                 ('marker-position  (setf (nskk-state-marker-position  state) value) value)
+                 ('previous-mode    (setf (nskk-state-previous-mode    state) value) value)
+                 ('undo-stack       (setf (nskk-state-undo-stack       state) value) value)
+                 ('redo-stack       (setf (nskk-state-redo-stack       state) value) value)
+                 ('metadata         (setf (nskk-state-metadata         state) value) value)
+                 (_ nil))))
+          (if result (succeed result) (fail))))
+    (fail)))
 
 ;;;; State Slot Defaults — static cache, no Prolog round-trip per create/reset
 ;;
@@ -505,7 +505,7 @@ or state is invalid.
 Properly handles multibyte characters."
   (if (nskk-state-p state)
       (let ((buf (nskk-state-input-buffer state)))
-        (if (and (stringp buf) (> (length buf) 0))
+        (if (and (stringp buf) (not (string-empty-p buf)))
             (let* ((new-len  (1- (length buf)))
                    (last-char (aref buf new-len))
                    (new-buf   (substring buf 0 new-len)))

--- a/nskk-trie.el
+++ b/nskk-trie.el
@@ -14,12 +14,12 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -37,6 +37,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (eval-when-compile (require 'nskk-cps-macros))
 
 ;;;; Trie Node Structure
@@ -101,7 +102,7 @@ modest for leaf-heavy subtrees.")
   "Insert KEY with VALUE into TRIE."
   (unless (stringp key)
     (error "Key must be a string: %s" key))
-  (when (zerop (length key))
+  (when (string-empty-p key)
     (error "Key cannot be empty"))
   (let ((node (nskk-trie-root trie))
         (was-new nil))
@@ -191,7 +192,7 @@ Returns a list of (key . value) pairs.
 If LIMIT is non-nil, return at most LIMIT results."
   (unless (stringp prefix)
     (error "Prefix must be a string: %s" prefix))
-  (let ((node (if (zerop (length prefix))
+  (let ((node (if (string-empty-p prefix)
                   (nskk-trie-root trie)
                 (nskk--trie-find-node trie prefix))))
     (when node
@@ -224,7 +225,7 @@ This means PREFIX is either a complete key or a proper prefix of some key.
 O(k) where k = length of PREFIX."
   (unless (stringp prefix)
     (error "Prefix must be a string: %s" prefix))
-  (if (zerop (length prefix))
+  (if (string-empty-p prefix)
       (nskk-trie-root trie)
     (nskk--trie-find-node trie prefix)))
 

--- a/test/bench/nskk-bench.el
+++ b/test/bench/nskk-bench.el
@@ -45,6 +45,8 @@
 (require 'cl-lib)
 (require 'nskk-test-framework)
 
+(declare-function nskk-mode "nskk")
+
 ;;;; ── Benchmark Infrastructure ────────────────────────────────────────────────
 
 (defvar nskk-bench--results nil

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -716,7 +716,7 @@ This ensures:
         (nskk-e2e-with-azik-buffer 'hiragana nil
           (nskk-e2e-type r)
           (nskk-e2e-type "C-j")
-          (should (> (length (buffer-string)) 0)))))))
+          (should (not (string-empty-p (buffer-string)))))))))
 
 ;;;
 ;;; AZIK @ Key in ▽ Preedit — Script Conversion (DDSKK-compatible)

--- a/test/e2e/nskk-dcomp-e2e-test.el
+++ b/test/e2e/nskk-dcomp-e2e-test.el
@@ -194,11 +194,10 @@ Adds \"さくら\" and \"にほん\" to cover prefixes outside the \"かん\" cl
   :body
   (nskk-e2e-with-buffer 'hiragana nskk-e2e--dcomp-dict-extended
     (nskk-e2e-type input)
-    (let ((before (nskk-preedit-string)))
+    (let ((_before (nskk-preedit-string)))
       (nskk-e2e-type "TAB")
       ;; After Tab with a known prefix, preedit must be a valid string.
       (should (stringp (nskk-preedit-string)))
-      ;; Suppress unused-variable warning: expected is always t (crash-free).
       (should expected))))
 
 ;;;;
@@ -213,7 +212,7 @@ Adds \"さくら\" and \"にほん\" to cover prefixes outside the \"かん\" cl
       (nskk-e2e-type "TAB")
       ;; Confirm we are still in preedit phase with an extended reading.
       (nskk-e2e-assert-henkan-phase 'on)
-      (should (> (length (nskk-preedit-string)) 0))
+      (should (not (string-empty-p (nskk-preedit-string))))
       ;; SPC should trigger henkan conversion.
       (nskk-e2e-type "SPC")
       ;; Now we should be in active conversion phase (▼).
@@ -230,7 +229,7 @@ Adds \"さくら\" and \"にほん\" to cover prefixes outside the \"かん\" cl
       ;; After commit, henkan phase returns to nil.
       (nskk-e2e-assert-henkan-phase nil)
       ;; Buffer should contain the committed kana (non-empty).
-      (should (> (length (buffer-string)) 0)))))
+      (should (not (string-empty-p (buffer-string)))))))
 
 ;;;;
 ;;;; dcomp C-g after Tab cancels preedit
@@ -244,7 +243,7 @@ Adds \"さくら\" and \"にほん\" to cover prefixes outside the \"かん\" cl
       (nskk-e2e-type "TAB")
       ;; Preedit is extended at this point.
       (nskk-e2e-assert-henkan-phase 'on)
-      (should (> (length (nskk-preedit-string)) 0))
+      (should (not (string-empty-p (nskk-preedit-string))))
       ;; C-g cancels preedit.
       (nskk-e2e-type "C-g")
       ;; After cancellation, henkan phase is nil.

--- a/test/e2e/nskk-navigation-e2e-test.el
+++ b/test/e2e/nskk-navigation-e2e-test.el
@@ -355,7 +355,7 @@
 ;;;;
 
 (nskk-deftest-table navigation-point-invariants
-  :columns (input expected)
+  :columns (input _expected)
   :rows (("C-f" "forward")
          ("C-b" "backward"))
   :body

--- a/test/e2e/nskk-numeric-e2e-test.el
+++ b/test/e2e/nskk-numeric-e2e-test.el
@@ -158,7 +158,7 @@ Three candidates: #0 = literal, #2 = kanji digit-by-digit, #3 = place values.")
 ;; (The generator draws any valid mode; we only run the body in hiragana so
 ;; the property is always checked with a consistent mode.)
 (nskk-property-test-seeded numeric-hiragana-no-crash
-  ((_unused valid-mode))
+  ((unused valid-mode))
   (condition-case _err
       (progn
         (nskk-e2e-with-buffer 'hiragana nskk-e2e--numeric-dict

--- a/test/e2e/nskk-okurigana-e2e-test.el
+++ b/test/e2e/nskk-okurigana-e2e-test.el
@@ -1079,7 +1079,7 @@
           (nskk-e2e-type "K")
           (nskk-e2e-type "E"))
         (should (stringp captured-prompt))
-        (should (string-match "ほ\\*け" captured-prompt)))))
+        (should (string-match-p "ほ\\*け" captured-prompt)))))
 
   (nskk-it "cancelling okurigana registration preserves preedit ▽ほけ (okuri-kana stays)"
     ;; After cancel (empty RET), the okuri-kana remains in the buffer.
@@ -1113,7 +1113,7 @@
 
 (nskk-deftest-table okurigana-basic-consonants
   :description "All standard okurigana consonant markers are uppercase ASCII"
-  :columns (input expected)
+  :columns (input _expected)
   :rows (("K" "K")
          ("S" "S")
          ("T" "T")

--- a/test/integration/nskk-azik-integration-test.el
+++ b/test/integration/nskk-azik-integration-test.el
@@ -182,7 +182,7 @@
                   (cl-loop for ch across pattern
                            do (nskk--integration-type-char ch))
                   (unless (and (stringp (buffer-string))
-                               (> (length (buffer-string)) 0))
+                               (not (string-empty-p (buffer-string))))
                     (push pattern failures)))
               (error (push (list :error pattern err) failures)))))
         (when failures
@@ -203,7 +203,7 @@
         (cl-loop for ch across input-str
                  do (nskk--integration-type-char ch))
         (and (stringp (buffer-string))
-             (> (length (buffer-string)) 0))))
+             (not (string-empty-p (buffer-string))))))
     30))
 
 (provide 'nskk-azik-integration-test)

--- a/test/integration/nskk-conversion-flow-pbt-test.el
+++ b/test/integration/nskk-conversion-flow-pbt-test.el
@@ -117,7 +117,7 @@
 (nskk-property-test nskk-state-machine-conversion-roundtrip
   ((candidates candidate-list))
   (let* ((state (nskk--pbt-make-conversion-state))
-         (input-before (nskk-state-input-buffer state)))
+         (_input-before (nskk-state-input-buffer state)))
     ;; Start conversion with candidates
     (nskk--pbt-start-conversion state candidates)
     ;; Commit conversion
@@ -125,7 +125,7 @@
     ;; Verify: converted-buffer should contain the first candidate
     (let ((converted (nskk-state-converted-buffer state)))
       (and (stringp converted)
-           (> (length converted) 0)
+           (not (string-empty-p converted))
            (member (car candidates) (list converted)))))
   50)
 
@@ -228,7 +228,7 @@
       (let ((op (nskk--pbt-random-int 0 2)))
         (pcase op
           (0 ;; Start conversion
-           (when (> (length (nskk-state-input-buffer state)) 0)
+           (when (not (string-empty-p (nskk-state-input-buffer state)))
              (nskk--pbt-start-conversion state candidates)))
           (1 ;; Cancel conversion
            (nskk--pbt-cancel-conversion state original-input))
@@ -245,7 +245,7 @@
       ;; (no dangling henkan-position with empty candidates)
       (let ((consistent t))
         ;; Invariant 2: current-index should be valid for candidates list
-        (when (and cands (> (length cands) 0))
+        (when cands
           (unless (and (integerp idx) (>= idx 0) (< idx (length cands)))
             (setq consistent nil)))
         ;; Invariant 3: buffers should always be strings
@@ -278,7 +278,7 @@
     ;; After commit, converted-buffer must be a non-empty string
     (let ((converted (nskk-state-converted-buffer state)))
       (and (stringp converted)
-           (> (length converted) 0))))
+           (not (string-empty-p converted)))))
   50)
 
 ;;;
@@ -335,7 +335,7 @@
         (nskk-then
           (let ((converted (nskk-state-converted-buffer state)))
             (should (stringp converted))
-            (should (> (length converted) 0))
+            (should (not (string-empty-p converted)))
             (should (nskk-state-p state))))))))
 
 
@@ -373,7 +373,7 @@
            (lambda () (setq branch-called 'fail)))
           (when (eq branch-called 'match)
             (unless (and (stringp result-value)
-                         (> (length result-value) 0))
+                         (not (string-empty-p result-value)))
               (push (list :romaji romaji :result result-value) failures)))))
       (when failures
         (ert-fail (format "on-match received non-string for %d cases:\n%S"

--- a/test/integration/nskk-custom-integration-test.el
+++ b/test/integration/nskk-custom-integration-test.el
@@ -554,7 +554,7 @@
       (nskk-with-state nskk-state-default-mode
         (let ((indicator (nskk-modeline-indicator)))
           (should (stringp indicator))
-          (should (> (length indicator) 0))))))
+          (should (not (string-empty-p indicator)))))))
 
   (nskk-it "modeline differs between hiragana and katakana default modes"
     (let ((nskk-use-color-cursor nil))

--- a/test/integration/nskk-dictionary-integration-pbt-test.el
+++ b/test/integration/nskk-dictionary-integration-pbt-test.el
@@ -156,9 +156,9 @@
     (should (and parsed
                  (consp parsed)
                  (stringp (car parsed))
-                 (> (length (car parsed)) 0)
+                 (not (string-empty-p (car parsed)))
                  (listp (cdr parsed))
-                 (> (length (cdr parsed)) 0))))
+                 (cdr parsed))))
   50)
 
 

--- a/test/integration/nskk-henkan-pipeline-integration-test.el
+++ b/test/integration/nskk-henkan-pipeline-integration-test.el
@@ -158,7 +158,7 @@
 (require 'nskk-pbt-generators)
 
 (nskk-deftest-table henkan-pipeline-preedit-sequences
-  :columns (input expected)
+  :columns (input _expected)
   :rows (("kanji" "かんじ")
          ("umi"   "うみ")
          ("sora"  "そら"))
@@ -168,7 +168,7 @@
       (dolist (ch (string-to-list input))
         (nskk--integration-type-char ch))
       ;; After typing, buffer-string should be non-empty (▽ + kana)
-      (should (> (length (buffer-string)) 0)))))
+      (should (not (string-empty-p (buffer-string)))))))
 
 (nskk-property-test henkan-pipeline-preedit-does-not-crash
   ((r romaji-basic))

--- a/test/integration/nskk-input-routing-pbt-test.el
+++ b/test/integration/nskk-input-routing-pbt-test.el
@@ -120,7 +120,7 @@
 ;;;;
 
 (nskk-property-test nskk-pbt-hiragana-mode-converts
-  ((_dummy lowercase-char))
+  ((dummy lowercase-char))
   ;; Property: In Hiragana mode, vowels are converted to hiragana.
   (let* ((vowel-map '((?a . "あ") (?i . "い") (?u . "う") (?e . "え") (?o . "お")))
          (pair (nskk--pbt-random-choice vowel-map))
@@ -134,7 +134,7 @@
   30)
 
 (nskk-property-test nskk-pbt-katakana-mode-converts
-  ((_dummy lowercase-char))
+  ((dummy lowercase-char))
   ;; Property: In Katakana mode, vowels are converted to katakana.
   (let* ((vowel-map '((?a . "ア") (?i . "イ") (?u . "ウ") (?e . "エ") (?o . "オ")))
          (pair (nskk--pbt-random-choice vowel-map))

--- a/test/integration/nskk-modeline-state-integration-test.el
+++ b/test/integration/nskk-modeline-state-integration-test.el
@@ -44,7 +44,7 @@
   (nskk-it "returns non-empty string for hiragana mode"
     (nskk-with-state 'hiragana
       (let ((nskk-use-color-cursor nil))
-        (should (> (length (nskk-modeline-indicator)) 0)))))
+        (should (not (string-empty-p (nskk-modeline-indicator)))))))
 
   (nskk-it "hiragana indicator contains かな"
     (nskk-with-state 'hiragana

--- a/test/integration/nskk-prolog-integration-test.el
+++ b/test/integration/nskk-prolog-integration-test.el
@@ -114,7 +114,7 @@
       (let ((vals (nskk-prolog-query-all-values '(color-set \?c) '\?c)))
         (nskk-then
          (should (equal (sort (copy-sequence vals) #'string<)
-                        (sort '(red green blue) #'string<))))))))
+                        (sort (list 'red 'green 'blue) #'string<))))))))
 
 ;;;; Group 2: Retraction
 
@@ -274,10 +274,10 @@
                                   collect (nskk-generate 'search-query)))
              (all-keys (cons prefix extra-keys)))
         (dolist (k all-keys)
-          (when (and (stringp k) (> (length k) 0))
+          (when (and (stringp k) (not (string-empty-p k)))
             (nskk-prolog-assert `((pbt-trie-test ,k ("dummy"))))))
         ;; Collect prefix-search results
-        (let* ((prefix-results (when (and (stringp prefix) (> (length prefix) 0))
+        (let* ((prefix-results (when (and (stringp prefix) (not (string-empty-p prefix)))
                                  (nskk-prolog-trie-prefix-search 'pbt-trie-test 2 prefix)))
                ;; Collect all keys via full Prolog query
                (all-result-keys (nskk-prolog-query-all-values

--- a/test/integration/nskk-search-cache-integration-test.el
+++ b/test/integration/nskk-search-cache-integration-test.el
@@ -147,7 +147,7 @@
           (should (nskk-dict-entry-p entry))
           (let ((candidates (nskk-dict-entry-candidates entry)))
             (should (listp candidates))
-            (should (> (length candidates) 0))
+            (should candidates)
             (should (member "漢字" candidates)))))))
 
   (nskk-it "exact match search returns nil for a key not in the dictionary"
@@ -164,7 +164,7 @@
         (nskk-then
           (should (nskk-dict-entry-p result1))
           ;; After the miss the key should now be in the cache
-          (should (not (null (nskk-cache-get cache cache-key))))
+          (should (nskk-cache-get cache cache-key))
           ;; Stats: 1 miss from the first nskk-search-with-cache call
           (let ((stats (nskk-cache-stats cache)))
             (should (>= (plist-get stats :misses) 1))))

--- a/test/integration/nskk-search-strategy-integration-test.el
+++ b/test/integration/nskk-search-strategy-integration-test.el
@@ -103,7 +103,7 @@ with the mock-dict fixture.  `nskk-with-prolog-entries' calls
       (let ((idx (make-nskk-dict-index :predicate 'user-dict-entry)))
         (let ((results (nskk-search idx "かん" 'prefix)))
           (should (listp results))
-          (should (> (length results) 0))))))
+          (should results)))))
 
   (nskk-it "prefix search for かん finds all four かん-prefixed entries"
     (nskk-search-strategy--with-fixture
@@ -141,7 +141,7 @@ with the mock-dict fixture.  `nskk-with-prolog-entries' calls
       (let ((idx (make-nskk-dict-index :predicate 'user-dict-entry)))
         (let ((results (nskk-search idx "かん" 'partial)))
           (should (listp results))
-          (should (> (length results) 0))))))
+          (should results)))))
 
   (nskk-it "every partial result key contains the query substring"
     (nskk-search-strategy--with-fixture

--- a/test/integration/nskk-sequence-test.el
+++ b/test/integration/nskk-sequence-test.el
@@ -81,7 +81,7 @@ KEY is a string representing the key (e.g., \"a\", \"C-j\", \"q\")."
       state)
      ;; Regular character input
      ((and (stringp key) (= (length key) 1))
-      (let* ((char (aref key 0))
+      (let* ((_char (aref key 0))
              (current-buffer (nskk-state-input-buffer state)))
         ;; Append to input buffer
         (nskk-state-set state 'input-buffer (concat current-buffer key))

--- a/test/integration/nskk-state-machine-buffer-test.el
+++ b/test/integration/nskk-state-machine-buffer-test.el
@@ -251,15 +251,15 @@
       (nskk-when
         (nskk-state-append-input state ?a))
       (nskk-then
-        (should (not (null (nskk-state-input-buffer state)))))
+        (should (nskk-state-input-buffer state)))
       (nskk-when
         (nskk-state-delete-last-char state))
       (nskk-then
-        (should (not (null (nskk-state-input-buffer state)))))
+        (should (nskk-state-input-buffer state)))
       (nskk-when
         (nskk-state-clear-input state))
       (nskk-then
-        (should (not (null (nskk-state-input-buffer state)))))))
+        (should (nskk-state-input-buffer state)))))
 
   (nskk-it "buffer is always a string after any operation"
     (let ((state (nskk-state-create 'hiragana)))
@@ -433,7 +433,7 @@
         (nskk-state-append-input state ?漢)
         (nskk-state-append-input state ?🔥))
       (nskk-then
-        (should (> (length (nskk-state-input-buffer state)) 0))
+        (should (not (string-empty-p (nskk-state-input-buffer state))))
         (should (stringp (nskk-state-input-buffer state)))))))
 
 

--- a/test/integration/nskk-state-machine-candidate-test.el
+++ b/test/integration/nskk-state-machine-candidate-test.el
@@ -563,8 +563,8 @@ COUNT defaults to 0-10 if not specified."
             (nskk-state-previous-candidate state)))
         (let ((idx (nskk-state-current-index state))
               (len (length (nskk-state-candidates state))))
-          (or (= len 0)
-              (and (>= idx 0) (< idx len))))))))
+          (should (or (= len 0)
+                      (and (>= idx 0) (< idx len)))))))))
 
 
 (provide 'nskk-state-machine-candidate-test)

--- a/test/nskk-e2e-helpers.el
+++ b/test/nskk-e2e-helpers.el
@@ -146,10 +146,9 @@ Initialization order:
   7. Teardown: disable nskk-mode, reset global state"
   (declare (indent 2) (debug t))
   `(nskk-prolog-test-with-isolated-db
-     ;; Step 1: Assert (dict-initialized) BEFORE enabling nskk-mode.
+     ;; Assert (dict-initialized) BEFORE enabling nskk-mode.
      ;; This prevents nskk-dict-initialize from running and wiping our mock.
      (nskk-prolog-assert '((dict-initialized)))
-     ;; Step 2: Set up mock user-dict-entry facts.
      ;; Must use user-dict-entry (NOT mock-dict-entry) so dict-entry/2 bridge works.
      (nskk-prolog-retract-all 'user-dict-entry 2)
      (nskk-prolog-set-index 'user-dict-entry 2 :trie)
@@ -157,7 +156,6 @@ Initialization order:
        (dolist (entry nskk-e2e--entries)
          (nskk-prolog-assert
           `((user-dict-entry ,(car entry) ,(cdr entry))))))
-     ;; Step 3: Enable nskk-mode in a temp buffer.
      (with-temp-buffer
        ;; Clear any pending keyboard events from previous execute-kbd-macro calls.
        ;; In Emacs batch mode, unread-command-events can persist between calls
@@ -174,14 +172,13 @@ Initialization order:
                  ((symbol-function 'nskk-candidate-hide-list)
                   #'ignore))
          (nskk-mode 1)
-         ;; Step 4: Set initial mode after nskk-mode activation.
+         ;; Set initial mode after nskk-mode activation.
          (when ,initial-mode
            (nskk--set-mode ,initial-mode))
          ;; Clear any residual romaji buffer.
          (setq nskk--romaji-buffer "")
          (unwind-protect
              (progn ,@body)
-           ;; Step 5: Teardown.
            (ignore-errors (nskk-mode -1))
            ;; Clear any events we produced, so the next test starts clean.
            (setq unread-command-events nil)
@@ -228,7 +225,7 @@ dispatching raw character codes directly from the string."
   `(let* ((keys-val ,keys)
           (key-vec  (kbd keys-val)))
      (if (and (stringp keys-val)
-              (> (length keys-val) 0)
+              (not (string-empty-p keys-val))
               (zerop (length key-vec)))
          ;; Fallback: kbd parsed the string as empty (e.g., ";;" is a comment).
          ;; Dispatch each character code directly.

--- a/test/nskk-pbt-generators.el
+++ b/test/nskk-pbt-generators.el
@@ -58,6 +58,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'nskk-test-framework)
 
 ;;;;
@@ -261,13 +262,13 @@ COUNT defaults to 0-10 if not specified."
                        (cond
                         ((= candidate-type 0)
                          ;; Hiragana candidate
-                         (mapconcat #'identity
+                         (string-join
                                    (cl-loop repeat (nskk--pbt-random-int 1 5)
                                             collect (nskk--pbt-random-choice hiragana-chars))
                                    ""))
                         ((= candidate-type 1)
                          ;; Kanji candidate
-                         (mapconcat #'identity
+                         (string-join
                                    (cl-loop repeat (nskk--pbt-random-int 1 3)
                                             collect (nskk--pbt-random-choice kanji-chars))
                                    ""))
@@ -376,14 +377,14 @@ SIZE controls the complexity of generated state."
 
 (defun nskk--pbt-generate-romaji-pattern (&optional size type)
   "Generate a romaji pattern with optional SIZE and TYPE.
-TYPE can be 'basic, 'extended, 'incomplete, or nil for random."
+TYPE can be `basic', `extended', `incomplete', or nil for random."
   (let* ((sz (nskk--pbt-resolve-size size 3))
          (pattern-type (or type
                           (nskk--pbt-random-choice '(basic extended mixed incomplete)))))
     (cl-case pattern-type
       (basic
        ;; Basic patterns only
-       (mapconcat #'identity
+       (string-join
                   (cl-loop repeat sz
                            collect (nskk--pbt-random-choice
                                     (append nskk--pbt-basic-vowels
@@ -391,7 +392,7 @@ TYPE can be 'basic, 'extended, 'incomplete, or nil for random."
                   ""))
       (extended
        ;; Extended patterns including special
-       (mapconcat #'identity
+       (string-join
                   (cl-loop repeat sz
                            collect (nskk--pbt-random-choice
                                     (append nskk--pbt-consonant-vowel-basic
@@ -403,7 +404,7 @@ TYPE can be 'basic, 'extended, 'incomplete, or nil for random."
        (if (nskk--pbt-random-bool)
            (nskk--pbt-random-choice nskk--pbt-incomplete-patterns)
          ;; Mixed: complete syllables + incomplete ending
-         (concat (mapconcat #'identity
+         (concat (string-join
                            (cl-loop repeat (max 0 (1- sz))
                                     collect (nskk--pbt-random-choice
                                              (append nskk--pbt-consonant-vowel-basic
@@ -412,7 +413,7 @@ TYPE can be 'basic, 'extended, 'incomplete, or nil for random."
                  (nskk--pbt-random-choice nskk--pbt-incomplete-patterns))))
       (t
        ;; Mixed: all types
-       (mapconcat #'identity
+       (string-join
                   (cl-loop repeat sz
                            collect (nskk--pbt-random-choice
                                     (append nskk--pbt-basic-vowels
@@ -596,7 +597,7 @@ Uses stratified sampling for efficiency when CATEGORY is nil."
 (nskk-register-generator 'okurigana-pattern
   (lambda (&optional prefix-length)
     (let* ((prefix-len (or prefix-length (nskk--pbt-random-int 1 5)))
-           (prefix (mapconcat #'identity
+           (prefix (string-join
                              (cl-loop repeat prefix-len
                                       collect (nskk--pbt-random-choice
                                                (append nskk--pbt-basic-vowels
@@ -609,7 +610,7 @@ Uses stratified sampling for efficiency when CATEGORY is nil."
 (nskk-register-generator 'okurigana-with-expected
   (lambda (&optional prefix-length)
     (let* ((prefix-len (or prefix-length (nskk--pbt-random-int 1 5)))
-           (prefix (mapconcat #'identity
+           (prefix (string-join
                              (cl-loop repeat prefix-len
                                       collect (nskk--pbt-random-choice
                                                (append nskk--pbt-basic-vowels
@@ -657,24 +658,24 @@ SIZE controls the length of the query."
          (query-type (nskk--pbt-random 4)))
     (cl-case query-type
       (0 ;; Hiragana only
-       (mapconcat #'identity
+       (string-join
                   (cl-loop repeat sz
                            collect (nskk--pbt-random-choice nskk--pbt-hiragana-chars))
                   ""))
       (1 ;; Katakana only
-       (mapconcat #'identity
+       (string-join
                   (cl-loop repeat sz
                            collect (nskk--pbt-random-choice nskk--pbt-katakana-chars))
                   ""))
       (2 ;; Mixed hiragana/katakana
-       (mapconcat #'identity
+       (string-join
                   (cl-loop repeat sz
                            collect (if (nskk--pbt-random-bool)
                                        (nskk--pbt-random-choice nskk--pbt-hiragana-chars)
                                      (nskk--pbt-random-choice nskk--pbt-katakana-chars)))
                   ""))
       (t ;; With okurigana marker
-       (let ((base (mapconcat #'identity
+       (let ((base (string-join
                              (cl-loop repeat (1- sz)
                                       collect (nskk--pbt-random-choice nskk--pbt-hiragana-chars))
                              "")))
@@ -827,16 +828,15 @@ TYPE specifies the expected type for proper shrinking."
      (floor (/ value 2)))
     (_
      ;; Generic shrinking: try to make value smaller
-     (cond
-      ((stringp value)
-       (when (> (length value) 0)
-         (substring value 0 (1- (length value)))))
-      ((listp value)
-       (when (> (length value) 0)
-         (cdr value)))
-      ((integerp value)
-       (floor (/ value 2)))
-      (t value)))))
+     (pcase value
+       ((pred stringp)
+        (when (> (length value) 0)
+          (substring value 0 (1- (length value)))))
+       ((pred listp)
+        (when (> (length value) 0)
+          (cdr value)))
+       ((pred integerp) (floor (/ value 2)))
+       (_ value)))))
 
 (defun nskk-pbt-classify (value &optional type)
   "Classify VALUE into a category for test result analysis.
@@ -858,17 +858,17 @@ TYPE specifies the classification type."
     ('search-type
      value)
     (_
-     (cond
-      ((stringp value)
-       (cond
-        ((string-match-p "^[a-z]+$" value) 'lowercase)
-        ((string-match-p "^[A-Z]+$" value) 'uppercase)
-        ((string-match-p "^[ぁ-ん]+$" value) 'hiragana)
-        ((string-match-p "^[ァ-ン]+$" value) 'katakana)
-        (t 'mixed)))
-      ((listp value) 'list)
-      ((integerp value) 'integer)
-      (t 'unknown)))))
+     (pcase value
+       ((pred stringp)
+        (cond
+         ((string-match-p "^[a-z]+$" value) 'lowercase)
+         ((string-match-p "^[A-Z]+$" value) 'uppercase)
+         ((string-match-p "^[ぁ-ん]+$" value) 'hiragana)
+         ((string-match-p "^[ァ-ン]+$" value) 'katakana)
+         (t 'mixed)))
+       ((pred listp)    'list)
+       ((pred integerp) 'integer)
+       (_ 'unknown)))))
 
 ;;;;
 ;;;; Statistics and Debugging
@@ -970,10 +970,8 @@ TYPE specifies the classification type."
   (lambda ()
     ;; A random non-empty list of kanji candidate strings.
     (let* ((pool '("漢字" "感じ" "桜" "海" "空" "山" "川" "花" "星" "月"))
-           (n (1+ (random (min 5 (length pool)))))
-           (result nil))
-      (dotimes (i n result)
-        (push (nth i pool) result)))))
+           (n (1+ (random (min 5 (length pool))))))
+      (seq-take pool n))))
 
 
 ;;;;

--- a/test/nskk-pbt-shrink.el
+++ b/test/nskk-pbt-shrink.el
@@ -348,36 +348,16 @@ Returns nil if CURRENT-MODE is already the simplest."
   "Generic shrinker that dispatches by type.
 Shrinks VALUE to minimal failing case for PROPERTY-FN.
 Returns smaller value of same type, or original if cannot shrink further."
-  (cond
-   ;; String
-   ((stringp value)
-    (nskk-shrink-string value property-fn))
-
-   ;; List (sequence)
-   ((listp value)
-    (nskk-shrink-sequence value property-fn))
-
-   ;; Vector (sequence)
-   ((vectorp value)
-    (let ((shrunk (nskk-shrink-sequence (append value nil) property-fn)))
-      (if (listp shrunk)
-          (vconcat shrunk)
-        shrunk)))
-
-   ;; NSKK State
-   ((nskk-state-p value)
-    (nskk-shrink-state value property-fn))
-
-   ;; Integer - try smaller values
-   ((integerp value)
-    (nskk-shrink-integer value property-fn))
-
-   ;; Float - try smaller values
-   ((floatp value)
-    (nskk-shrink-float value property-fn))
-
-   ;; Unknown type - cannot shrink
-   (t value)))
+  (pcase value
+    ((pred stringp)    (nskk-shrink-string value property-fn))
+    ((pred listp)      (nskk-shrink-sequence value property-fn))
+    ((pred vectorp)
+     (let ((shrunk (nskk-shrink-sequence (append value nil) property-fn)))
+       (if (listp shrunk) (vconcat shrunk) shrunk)))
+    ((pred nskk-state-p) (nskk-shrink-state value property-fn))
+    ((pred integerp)   (nskk-shrink-integer value property-fn))
+    ((pred floatp)     (nskk-shrink-float value property-fn))
+    (_ value)))
 
 (defun nskk-shrink-integer (value property-fn)
   "Shrink integer VALUE to minimal failing case for PROPERTY-FN.
@@ -491,19 +471,17 @@ Returns minimal failing case."
 
 (defun nskk--measure-size (value)
   "Measure the size of VALUE for shrinking comparison."
-  (cond
-   ((stringp value) (length value))
-   ((listp value) (length value))
-   ((vectorp value) (length value))
-   ((nskk-state-p value)
-    (+ (length (nskk-state-input-buffer value))
-       (length (nskk-state-converted-buffer value))
-       (length (nskk-state-candidates value))
-       (if (nskk-state-undo-stack value) 1 0)
-       (if (nskk-state-redo-stack value) 1 0)
-       (if (nskk-state-metadata value) 1 0)))
-   ((numberp value) (abs value))
-   (t 1)))
+  (pcase value
+    ((or (pred stringp) (pred listp) (pred vectorp)) (length value))
+    ((pred nskk-state-p)
+     (+ (length (nskk-state-input-buffer value))
+        (length (nskk-state-converted-buffer value))
+        (length (nskk-state-candidates value))
+        (if (nskk-state-undo-stack value) 1 0)
+        (if (nskk-state-redo-stack value) 1 0)
+        (if (nskk-state-metadata value) 1 0)))
+    ((pred numberp) (abs value))
+    (_ 1)))
 
 
 ;;;;
@@ -515,9 +493,9 @@ Returns minimal failing case."
 ITERATIONS is the current iteration count.
 CURRENT is the current shrunk value.
 ORIGINAL is the original value before shrinking."
-  (let ((orig-size (nskk--measure-size original))
-        (curr-size (nskk--measure-size current))
-        (reduction-percent (if (> orig-size 0)
+  (let* ((orig-size (nskk--measure-size original))
+         (curr-size (nskk--measure-size current))
+         (reduction-percent (if (> orig-size 0)
                                (* 100 (/ (float (- orig-size curr-size)) orig-size))
                              0)))
     (message "[NSKK Shrink] Iteration %d: %d -> %d (%.1f%% reduction)"

--- a/test/nskk-test-framework.el
+++ b/test/nskk-test-framework.el
@@ -36,6 +36,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'subr-x)
 (require 'nskk-dictionary)
 (require 'nskk-prolog)
 (require 'nskk-trie)
@@ -227,7 +228,7 @@
                    "た" "ち" "つ" "て" "と"
                    "な" "に" "ぬ" "ね" "の"))
           (len (or length (+ 1 (random 10)))))
-      (mapconcat #'identity
+      (string-join
                  (cl-loop repeat len
                           collect (nth (random (length chars)) chars))
                  ""))))
@@ -237,7 +238,7 @@
     (let ((chars '("漢" "字" "変" "換" "日" "本" "語"
                    "入" "力" "シ" "ス" "テ" "ム"))
           (len (or length (+ 1 (random 5)))))
-      (mapconcat #'identity
+      (string-join
                  (cl-loop repeat len
                           collect (nth (random (length chars)) chars))
                  ""))))
@@ -280,14 +281,19 @@ test body cannot mutate the saved snapshot."
   "Deep-copy hash table HT for test isolation.
 Lists are shallow-copied with `copy-sequence'.  Trie structures are
 recursively deep-copied so that in-place mutations in the test body
-do not persist through restoration.  All other values are shared
-by reference."
+do not persist through restoration.  Nested hash tables (used as Prolog
+index stores, e.g. for hash-indexed predicates like `dict-annotation')
+are recursively deep-copied so mutations to index entries do not leak
+across tests via shared references.  All other values are shared by
+reference."
   (let ((new (make-hash-table :test (hash-table-test ht)
                               :size (hash-table-size ht))))
     (maphash (lambda (k v)
                (puthash k (cond
                            ((nskk-trie-p v)
                             (nskk-prolog-test--copy-trie v))
+                           ((hash-table-p v)
+                            (nskk-prolog-test--copy-hash-table v))
                            ((sequencep v)
                             (copy-sequence v))
                            (t v))
@@ -334,7 +340,9 @@ after the test ends."
          (saved-converter-init  (and (boundp 'nskk--converter-initialized)
                                      nskk--converter-initialized))
          (saved-cand-init       (and (boundp 'nskk--candidate-key-facts-initialized)
-                                     nskk--candidate-key-facts-initialized)))
+                                     nskk--candidate-key-facts-initialized))
+         (saved-annotation-init (and (boundp 'nskk--annotation-initialized)
+                                     nskk--annotation-initialized)))
      (when (boundp 'nskk--input-initialized)
        (setq nskk--input-initialized nil))
      (when (boundp 'nskk--state-prolog-initialized)
@@ -347,6 +355,8 @@ after the test ends."
        (setq nskk--converter-initialized nil))
      (when (boundp 'nskk--candidate-key-facts-initialized)
        (setq nskk--candidate-key-facts-initialized nil))
+     (when (boundp 'nskk--annotation-initialized)
+       (setq nskk--annotation-initialized nil))
      (unwind-protect
          (progn ,@body)
        (setq nskk--prolog-database    saved-db
@@ -368,6 +378,8 @@ after the test ends."
          (setq nskk--converter-initialized saved-converter-init))
        (when (boundp 'nskk--candidate-key-facts-initialized)
          (setq nskk--candidate-key-facts-initialized saved-cand-init))
+       (when (boundp 'nskk--annotation-initialized)
+         (setq nskk--annotation-initialized saved-annotation-init))
        ;; Re-derive database-tails from the now-restored database.
        ;; `copy-sequence' on a list creates a new cons-cell spine, so any
        ;; separately saved tail would point to cells that are not the actual
@@ -568,7 +580,7 @@ This helper is shared by both `nskk-server-integration-test' and
               :coding nskk-server-coding-system
               :filter
               (lambda (client string)
-                (when (> (length string) 0)
+                (when (not (string-empty-p string))
                   (let ((cmd (aref string 0)))
                     (cond
                      ((= cmd ?0)

--- a/test/nskk-test-macros.el
+++ b/test/nskk-test-macros.el
@@ -110,7 +110,7 @@ RUNS: Number of test runs (default: nskk-test-property-runs)"
   "Return a list of smaller versions of LIST for shrinking.
 Returns the first shrinking candidate that reduces size.
 Note: this is a local helper; use `nskk-pbt-shrink.el' for full shrinking."
-  (when (and list (> (length list) 0))
+  (when list
     ;; Try removing first element
     (if (> (length list) 1)
         (cdr list)
@@ -183,7 +183,7 @@ SEED: Random seed for reproducibility (default: random)"
        (message "Property test (with shrinking) '%s' seed: %d" ',name test-seed)
        ;; First pass: find a failure
        (dotimes (_ runs)
-         (when (not failure-case)
+         (unless failure-case
            (let ,(mapcar (lambda (gen)
                            `(,(car gen) (nskk-generate ',(cadr gen))))
                          generators)
@@ -194,7 +194,7 @@ SEED: Random seed for reproducibility (default: random)"
                (error
                 (setq failure-case (list :error ,@(mapcar #'car generators) err))))))
          ;; Move to next random state if no failure yet
-         (when (not failure-case)
+         (unless failure-case
            (random)))
        ;; If we found a failure, try to shrink it
        (when failure-case
@@ -204,7 +204,7 @@ SEED: Random seed for reproducibility (default: random)"
                           collect (nskk--shrink-value val (cadr gen))))
                 (shrunk-case shrunk-values))
            ;; Try the shrunk case
-           (condition-case err
+           (condition-case _err
                (let ,(cl-loop for gen in generators
                               for i from 0
                               collect `(,(car gen) (nth ,i shrunk-case)))
@@ -240,7 +240,8 @@ NAME: Test name
 INITIAL-STATE: Expression to create initial state
 TRANSITIONS: List of (trigger target-state) pairs
 PROPERTY: Invariant that should hold after any transition
-RUNS: Number of transition sequences to test (default: nskk-test-state-machine-runs)
+RUNS: Number of transition sequences to test
+      (default: nskk-test-state-machine-runs)
 
 The test generates random sequences of transitions and verifies that
 the PROPERTY invariant holds after each transition."
@@ -480,7 +481,7 @@ BODY: Test implementation"
      ,@(mapcar (lambda (test)
                  `(progn
                     (message "  Running: %s" ',test)
-                    (funcall #',test)))
+                    (funcall ',test)))
                tests)
      (message "Test suite %s is complete" ',name)))
 
@@ -587,8 +588,9 @@ Example:
              (t form)))
           body))))
 
-(defmacro nskk-context (description &rest body)
-  "Provide sub-grouping under DESCRIPTION within a `nskk-describe' block.
+(defmacro nskk-context (_description &rest body)
+  "Provide sub-grouping within a `nskk-describe' block.
+_DESCRIPTION is a string label used only by `nskk-describe' for test naming.
 When used outside `nskk-describe', expands to a plain progn (no test naming).
 BODY may contain `nskk-it' forms and regular Emacs Lisp forms."
   (declare (indent 1))
@@ -897,7 +899,8 @@ Example:
 (defmacro nskk-with-henkan-state (phase candidates &rest body)
   "Execute BODY with henkan state set to PHASE with CANDIDATES.
 Provides bindings: `nskk-current-state', `nskk--conversion-start-marker',
-`nskk--romaji-buffer', `nskk--henkan-count', `nskk--henkan-candidate-list-active'."
+`nskk--romaji-buffer', `nskk--henkan-count',
+`nskk--henkan-candidate-list-active'."
   (declare (indent 2))
   `(with-temp-buffer
      (let ((nskk-current-state (nskk-state-create 'hiragana))

--- a/test/unit/nskk-annotation-test.el
+++ b/test/unit/nskk-annotation-test.el
@@ -1,0 +1,211 @@
+;;; nskk-annotation-test.el --- Tests for nskk-annotation.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 NSKK Authors
+
+;; Author: takeokunn <bararararatty@gmail.com>
+;; Keywords: japanese, input, test
+
+;; This file is part of NSKK.
+
+;;; Commentary:
+
+;; Tests for nskk-annotation.el covering:
+;; - Function existence (fboundp)
+;; - Prolog initialization (nskk-annotation-initialize)
+;; - Annotation registration and lookup
+;; - Annotation format helper
+;; - Display toggle (nskk--annotation-visible state)
+;; - nskk-annotation-clear
+;; - nskk-annotation-show-for-candidate guard conditions
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'nskk-annotation)
+(require 'nskk-prolog)
+(require 'nskk-test-framework)
+(require 'nskk-test-macros)
+
+;;;; Function Existence
+
+(nskk-describe "nskk-annotation function existence"
+  (nskk-it "nskk-annotation-initialize is defined"
+    (should (fboundp 'nskk-annotation-initialize)))
+  (nskk-it "nskk-annotation-register is defined"
+    (should (fboundp 'nskk-annotation-register)))
+  (nskk-it "nskk-annotation-lookup is defined"
+    (should (fboundp 'nskk-annotation-lookup)))
+  (nskk-it "nskk-annotation-clear is defined"
+    (should (fboundp 'nskk-annotation-clear)))
+  (nskk-it "nskk-annotation-toggle-display is defined"
+    (should (fboundp 'nskk-annotation-toggle-display)))
+  (nskk-it "nskk-annotation-show-for-candidate is defined"
+    (should (fboundp 'nskk-annotation-show-for-candidate))))
+
+;;;; Initialization
+
+(nskk-describe "nskk-annotation-initialize"
+  (nskk-it "is idempotent"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk-annotation-initialize)
+        (should nskk--annotation-initialized)))))
+
+;;;; Register and Lookup
+
+(nskk-describe "nskk-annotation-register and lookup"
+  (nskk-it "registers and retrieves an annotation"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk-annotation-register "かんじ" "漢字" "common kanji")
+        (should (equal (nskk-annotation-lookup "かんじ" "漢字") "common kanji")))))
+
+  (nskk-it "returns nil for unregistered reading+candidate"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (should (null (nskk-annotation-lookup "unknown" "候補"))))))
+
+  (nskk-it "returns nil when not initialized"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (should (null (nskk-annotation-lookup "かんじ" "漢字"))))))
+
+  (nskk-it "distinguishes different readings for same candidate"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk-annotation-register "かんじ" "漢字" "Chinese character")
+        (nskk-annotation-register "かんじる" "感じる" "to feel")
+        (should (equal (nskk-annotation-lookup "かんじ" "漢字") "Chinese character"))
+        (should (equal (nskk-annotation-lookup "かんじる" "感じる") "to feel")))))
+
+  (nskk-it "distinguishes different candidates for same reading"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk-annotation-register "かんじ" "漢字" "Chinese character")
+        (nskk-annotation-register "かんじ" "感じ" "feeling")
+        (should (equal (nskk-annotation-lookup "かんじ" "漢字") "Chinese character"))
+        (should (equal (nskk-annotation-lookup "かんじ" "感じ") "feeling"))))))
+
+;;;; Format Helper
+
+(nskk-describe "nskk--annotation-format"
+  (nskk-it "returns nil for nil annotation"
+    (should (null (nskk--annotation-format nil))))
+  (nskk-it "returns nil for empty string annotation"
+    (should (null (nskk--annotation-format ""))))
+  (nskk-it "returns a propertized string for non-empty annotation"
+    (let ((result (nskk--annotation-format "test annotation")))
+      (should (stringp result))
+      (should (string-match-p "test annotation" result))
+      (should (string-prefix-p " [" result))
+      (should (string-suffix-p "]" result))))
+  (nskk-it "applies nskk-annotation-face"
+    (let ((result (nskk--annotation-format "hello")))
+      (should (eq (get-text-property 0 'face result) 'nskk-annotation-face)))))
+
+;;;; Clear
+
+(nskk-describe "nskk-annotation-clear"
+  (nskk-it "clears nskk--annotation-current"
+    (with-temp-buffer
+      (setq nskk--annotation-current "some annotation")
+      (nskk-annotation-clear)
+      (should (null nskk--annotation-current)))))
+
+;;;; Show for Candidate Guards
+
+(nskk-describe "nskk-annotation-show-for-candidate"
+  (nskk-it "is a no-op when nskk-show-annotation is nil"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk-annotation-register "よみ" "候補" "note")
+        (with-temp-buffer
+          (let ((nskk-show-annotation nil))
+            ;; Should not error; annotation-current stays nil
+            (nskk-annotation-show-for-candidate "よみ" "候補")
+            (should (null nskk--annotation-current)))))))
+
+  (nskk-it "sets annotation-current when nskk-show-annotation is t"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk-annotation-register "よみ" "候補" "note text")
+        (with-temp-buffer
+          (let ((nskk-show-annotation t)
+                (message-log-max nil))
+            (nskk-annotation-show-for-candidate "よみ" "候補")
+            (should (equal nskk--annotation-current "note text")))))))
+
+  (nskk-it "sets annotation-current to nil for candidate without annotation"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (with-temp-buffer
+          (setq nskk--annotation-current "stale")
+          (let ((nskk-show-annotation t)
+                (message-log-max nil))
+            (nskk-annotation-show-for-candidate "よみ" "無注釈")
+            (should (null nskk--annotation-current))))))))
+
+;;;; Toggle Display
+
+(nskk-describe "nskk-annotation-toggle-display"
+  (nskk-it "toggles nskk--annotation-visible"
+    (with-temp-buffer
+      (let ((nskk--annotation-visible t))
+        (nskk-annotation-toggle-display)
+        (should (null nskk--annotation-visible))
+        (nskk-annotation-toggle-display)
+        (should nskk--annotation-visible))))
+
+  (nskk-it "does not error when toggling off with no current annotation"
+    (with-temp-buffer
+      (let ((nskk--annotation-visible t)
+            (nskk--annotation-current nil)
+            (message-log-max nil))
+        (should-not (condition-case err
+                        (progn (nskk-annotation-toggle-display) nil)
+                      (error err))))))
+
+  (nskk-it "does not error when toggling on with a current annotation"
+    (with-temp-buffer
+      (let ((nskk--annotation-visible nil)
+            (nskk--annotation-current "test note")
+            (message-log-max nil))
+        (should-not (condition-case err
+                        (progn (nskk-annotation-toggle-display) nil)
+                      (error err)))))))
+
+;;;; Load from Candidates Helper
+
+(nskk-describe "nskk--annotation-load-from-candidates"
+  (nskk-it "registers annotations from pair list"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk--annotation-load-from-candidates
+         "よみ"
+         '(("候補1" . "annotation1") ("候補2" . nil) ("候補3" . "annotation3")))
+        (should (equal (nskk-annotation-lookup "よみ" "候補1") "annotation1"))
+        (should (null  (nskk-annotation-lookup "よみ" "候補2")))
+        (should (equal (nskk-annotation-lookup "よみ" "候補3") "annotation3")))))
+
+  (nskk-it "skips empty annotation strings"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--annotation-initialized nil))
+        (nskk-annotation-initialize)
+        (nskk--annotation-load-from-candidates
+         "よみ"
+         '(("候補" . "")))
+        (should (null (nskk-annotation-lookup "よみ" "候補")))))))
+
+(provide 'nskk-annotation-test)
+
+;;; nskk-annotation-test.el ends here

--- a/test/unit/nskk-azik-test.el
+++ b/test/unit/nskk-azik-test.el
@@ -1794,7 +1794,7 @@
                  (result (nskk-convert-romaji input)))
             (unless (stringp result)
               (push (list :postcondition-failed :input input :result result) failures))
-            (unless (> (length result) 0)
+            (when (string-empty-p result)
               (push (list :invariant-failed "result is empty string" input) failures)))))
       (when failures
         (ert-fail (format "Contract test `nskk-convert-romaji' AZIK: %d failures:\n%S"

--- a/test/unit/nskk-cache-test.el
+++ b/test/unit/nskk-cache-test.el
@@ -1425,7 +1425,7 @@
   (nskk-it "removing one entry does not destroy a multi-entry bucket"
     (let* ((cache (nskk-cache-lfu-create 10))
            (e1 (nskk-cache-lfu-entry--create :key "k1" :value 1 :frequency 2))
-           (e2 (nskk-cache-lfu-entry--create :key "k2" :value 2 :frequency 2)))
+           (_e2 (nskk-cache-lfu-entry--create :key "k2" :value 2 :frequency 2)))
       ;; set up freq 1 bucket with both k1 and k2
       (let ((b1 (make-hash-table :test 'equal :size 4)))
         (puthash "k1" t b1)

--- a/test/unit/nskk-context-test.el
+++ b/test/unit/nskk-context-test.el
@@ -1,0 +1,187 @@
+;;; nskk-context-test.el --- Tests for nskk-context.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 NSKK Authors
+
+;; Author: takeokunn <bararararatty@gmail.com>
+;; Keywords: japanese, input, test
+
+;; This file is part of NSKK.
+
+;;; Commentary:
+
+;; Tests for nskk-context.el covering:
+;; - Function existence (fboundp)
+;; - Customization variables
+;; - nskk--context-programming-mode-p in prog-mode vs text-mode
+;; - nskk--context-in-japanese-context-p (string/comment syntax)
+;; - nskk--context-get-current-mode returns nil / mode symbol
+;; - Minor mode hook registration and teardown
+;; - nskk--context-maybe-enable only activates in prog-mode
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'nskk-context)
+(require 'nskk-state)
+(require 'nskk-prolog)
+(require 'nskk-test-framework)
+(require 'nskk-test-macros)
+
+;;;; Function Existence
+
+(nskk-describe "nskk-context function existence"
+  (nskk-it "nskk-context-mode is defined"
+    (should (fboundp 'nskk-context-mode)))
+  (nskk-it "nskk-context-global-mode is defined"
+    (should (fboundp 'nskk-context-global-mode)))
+  (nskk-it "nskk--context-post-command is defined"
+    (should (fboundp 'nskk--context-post-command)))
+  (nskk-it "nskk--context-programming-mode-p is defined"
+    (should (fboundp 'nskk--context-programming-mode-p)))
+  (nskk-it "nskk--context-in-japanese-context-p is defined"
+    (should (fboundp 'nskk--context-in-japanese-context-p)))
+  (nskk-it "nskk--context-get-current-mode is defined"
+    (should (fboundp 'nskk--context-get-current-mode)))
+  (nskk-it "nskk--context-switch-to-ascii is defined"
+    (should (fboundp 'nskk--context-switch-to-ascii)))
+  (nskk-it "nskk--context-maybe-enable is defined"
+    (should (fboundp 'nskk--context-maybe-enable))))
+
+;;;; Customization Variables
+
+(nskk-describe "nskk-context customization variables"
+  (nskk-it "nskk-context-programming-mode is defined"
+    (should (boundp 'nskk-context-programming-mode)))
+  (nskk-it "nskk-context-programming-mode defaults to t"
+    (should (eq nskk-context-programming-mode t)))
+  (nskk-it "nskk-context-mode-off-message is a string"
+    (should (stringp nskk-context-mode-off-message)))
+  (nskk-it "nskk-context-check-interval is a natural number"
+    (should (natnump nskk-context-check-interval))))
+
+;;;; Programming Mode Detection
+
+(nskk-describe "nskk--context-programming-mode-p"
+  (nskk-it "returns non-nil in emacs-lisp-mode (prog-mode derived)"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (let ((nskk-context-programming-mode t))
+        (should (nskk--context-programming-mode-p)))))
+
+  (nskk-it "returns nil in text-mode (not prog-mode derived)"
+    (with-temp-buffer
+      (text-mode)
+      (let ((nskk-context-programming-mode t))
+        (should (null (nskk--context-programming-mode-p))))))
+
+  (nskk-it "returns nil when nskk-context-programming-mode is nil"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (let ((nskk-context-programming-mode nil))
+        (should (null (nskk--context-programming-mode-p))))))
+
+  (nskk-it "accepts list of specific modes"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (let ((nskk-context-programming-mode '(emacs-lisp-mode)))
+        (should (nskk--context-programming-mode-p)))))
+
+  (nskk-it "returns nil for non-matching mode list"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (let ((nskk-context-programming-mode '(python-mode)))
+        (should (null (nskk--context-programming-mode-p)))))))
+
+;;;; Japanese Context Detection
+
+(nskk-describe "nskk--context-in-japanese-context-p"
+  (nskk-it "returns nil at top-level code in emacs-lisp-mode"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (insert "(defun foo () ")
+      (should (null (nskk--context-in-japanese-context-p)))))
+
+  (nskk-it "returns non-nil inside a string literal"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (insert "(defun foo () \"inside string")
+      (should (nskk--context-in-japanese-context-p))))
+
+  (nskk-it "returns non-nil inside a line comment"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (insert ";; this is a comment")
+      (should (nskk--context-in-japanese-context-p)))))
+
+;;;; Get Current Mode
+
+(nskk-describe "nskk--context-get-current-mode"
+  (nskk-it "returns nil when nskk-current-state is nil"
+    (with-temp-buffer
+      (let ((nskk-current-state nil))
+        (should (null (nskk--context-get-current-mode))))))
+
+  (nskk-it "returns mode symbol from nskk-current-state"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'hiragana))
+        (should (eq (nskk--context-get-current-mode) 'hiragana)))))
+
+  (nskk-it "returns ascii mode when in ascii state"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'ascii))
+        (should (eq (nskk--context-get-current-mode) 'ascii))))))
+
+;;;; Minor Mode Hook Registration
+
+(nskk-describe "nskk-context-mode"
+  (nskk-it "adds post-command-hook when enabled"
+    (with-temp-buffer
+      (nskk-context-mode 1)
+      (unwind-protect
+          (should (memq #'nskk--context-post-command
+                        (buffer-local-value 'post-command-hook (current-buffer))))
+        (nskk-context-mode -1))))
+
+  (nskk-it "removes post-command-hook when disabled"
+    (with-temp-buffer
+      (nskk-context-mode 1)
+      (nskk-context-mode -1)
+      (should-not (memq #'nskk--context-post-command
+                        (buffer-local-value 'post-command-hook (current-buffer))))))
+
+  (nskk-it "resets internal state on disable"
+    (with-temp-buffer
+      (setq nskk--context-was-ascii t
+            nskk--context-command-count 5)
+      (nskk-context-mode 1)
+      (nskk-context-mode -1)
+      (should (null nskk--context-was-ascii))
+      (should (= nskk--context-command-count 0)))))
+
+;;;; Maybe Enable Helper
+
+(nskk-describe "nskk--context-maybe-enable"
+  (nskk-it "enables context-mode in prog-mode buffer"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (let ((nskk-context-programming-mode t))
+        (nskk--context-maybe-enable)
+        (unwind-protect
+            (should nskk-context-mode)
+          (nskk-context-mode -1)))))
+
+  (nskk-it "does not enable context-mode in text-mode buffer"
+    (with-temp-buffer
+      (text-mode)
+      (let ((nskk-context-programming-mode t))
+        (nskk--context-maybe-enable)
+        (should (null nskk-context-mode))))))
+
+(provide 'nskk-context-test)
+
+;;; nskk-context-test.el ends here

--- a/test/unit/nskk-converter-test.el
+++ b/test/unit/nskk-converter-test.el
@@ -248,8 +248,8 @@
   ((input romaji-string))
   ;; Non-empty romaji input always produces non-empty output.
   ;; Empty input is handled separately (returns "" by contract).
-  (or (zerop (length input))
-      (> (length (nskk-convert-romaji input)) 0))
+  (or (string-empty-p input)
+      (not (string-empty-p (nskk-convert-romaji input))))
   100)
 
 (nskk-deftest-performance conversion-basic-performance
@@ -369,6 +369,10 @@
 ;;;; Test Suite Organization
 ;;;;
 
+(declare-function nskk-performance-conversion-basic-performance nil)
+(declare-function nskk-performance-conversion-complex-performance nil)
+(declare-function nskk-performance-conversion-batch-performance nil)
+(declare-function nskk-performance-conversion-long-input-performance nil)
 (nskk-test-suite converter-performance
   nskk-performance-conversion-basic-performance
   nskk-performance-conversion-complex-performance
@@ -951,7 +955,7 @@
 (nskk-describe "nskk--standard-romaji-rules content"
   (nskk-it "is a non-empty list"
     (should (listp nskk--standard-romaji-rules))
-    (should (> (length nskk--standard-romaji-rules) 0)))
+    (should nskk--standard-romaji-rules))
 
   (nskk-it "contains only (romaji kana) string pairs"
     (dolist (rule nskk--standard-romaji-rules)
@@ -1402,7 +1406,7 @@
 ;; Property: nskk--convert-step/k always calls exactly one continuation.
 (nskk-property-test-seeded convert-step/k-pbt-calls-exactly-one-continuation
   ((input romaji-basic))
-  (when (and (stringp input) (> (length input) 0))
+  (when (and (stringp input) (not (string-empty-p input)))
     (let ((call-count 0))
       (nskk--convert-step/k input
         (lambda (_kana _rest) (cl-incf call-count))
@@ -1414,10 +1418,10 @@
 ;; Property: nskk--convert-step/k on-kana always receives a non-empty kana string.
 (nskk-property-test-seeded convert-step/k-pbt-on-kana-receives-string
   ((input romaji-basic))
-  (when (and (stringp input) (> (length input) 0))
+  (when (and (stringp input) (not (string-empty-p input)))
     (let ((result t))
       (nskk--convert-step/k input
-        (lambda (kana _rest) (setq result (and (stringp kana) (> (length kana) 0))))
+        (lambda (kana _rest) (setq result (and (stringp kana) (not (string-empty-p kana)))))
         (lambda (_partial) t)
         (lambda () t))
       result))
@@ -1428,7 +1432,7 @@
 ;; wrapper, so the old sync-vs-CPS consistency check does not apply.)
 (nskk-property-test-seeded convert-step/k-pbt-consistent-with-sync
   ((input romaji-basic))
-  (when (and (stringp input) (> (length input) 0))
+  (when (and (stringp input) (not (string-empty-p input)))
     (let ((result1 nil)
           (result2 nil))
       (nskk--convert-step/k input

--- a/test/unit/nskk-cps-macros-test.el
+++ b/test/unit/nskk-cps-macros-test.el
@@ -37,8 +37,53 @@
 
 
 ;;; -------------------------------------------------------------------
+;;; Forward declarations for test-internal defun/k helpers
+;;; These functions are defined inside nskk-it bodies (non-top-level),
+;;; so the byte-compiler requires forward declarations for their call sites.
+;;; -------------------------------------------------------------------
+
+;; defun/k helpers defined inside nskk-it bodies (generate base + /k)
+(declare-function nskk-cps-test--prop-runtime nil)
+(declare-function nskk-cps-test--prop-runtime/k nil)
+(declare-function nskk-cps-test--pcase-let*-fn nil)
+(declare-function nskk-cps-test--pcase-let*-fn/k nil)
+(declare-function nskk-cps-test--callcc-basic nil)
+(declare-function nskk-cps-test--callcc-basic/k nil)
+(declare-function nskk-cps-test--callcc-store nil)
+(declare-function nskk-cps-test--callcc-store/k nil)
+(declare-function nskk-cps-test--callcc-with-succeed nil)
+(declare-function nskk-cps-test--callcc-with-succeed/k nil)
+(declare-function nskk-cps-test--escape-basic nil)
+(declare-function nskk-cps-test--escape-basic/k nil)
+(declare-function nskk-cps-test--escape-no-continue nil)
+(declare-function nskk-cps-test--escape-no-continue/k nil)
+(declare-function nskk-cps-test--escape-no-escape nil)
+(declare-function nskk-cps-test--escape-no-escape/k nil)
+(declare-function nskk-cps-test--always-found nil)
+(declare-function nskk-cps-test--always-found/k nil)
+(declare-function nskk-cps-test--seq-caller nil)
+(declare-function nskk-cps-test--seq-caller/k nil)
+(declare-function nskk-cps-test--always-failed nil)
+(declare-function nskk-cps-test--always-failed/k nil)
+(declare-function nskk-cps-test--seq-fail-caller nil)
+(declare-function nskk-cps-test--seq-fail-caller/k nil)
+(declare-function nskk-cps-test--seq-side-effect-caller nil)
+(declare-function nskk-cps-test--seq-side-effect-caller/k nil)
+;; defun/done helpers defined inside nskk-it bodies (generate base + /k)
+(declare-function nskk--cps-test-done-fn-guard nil)
+(declare-function nskk--cps-test-done-fn-guard/k nil)
+(declare-function nskk-cps-test--prop-done-runtime nil)
+(declare-function nskk-cps-test--prop-done-runtime/k nil)
+;; defun/3k helpers defined inside nskk-it bodies (generate /k only)
+(declare-function nskk--cps-3k-put-prop-test/k nil)
+(declare-function nskk--cps-3k-runtime-test/k nil)
+
+;;; -------------------------------------------------------------------
 ;;; Test helpers
 ;;; -------------------------------------------------------------------
+
+(defvar nskk--cps-test-action-result nil
+  "Holds the side-effect result for defun/done functional tests.")
 
 (defun nskk-cps-test--funcall-sym-named-p (form name)
   "Return t if FORM is (funcall SYM ...) where SYM has `symbol-name' NAME.
@@ -1067,7 +1112,7 @@ that the second element is a symbol with the given name."
 
     (nskk-it "the /k symbol has the :3k property after evaluation at runtime"
       (defun/3k nskk--cps-3k-put-prop-test ()
-          (on-a on-b on-c)
+          (on-a _on-b _on-c)
         "Test."
         (funcall on-a nil))
       (should (eq (get 'nskk--cps-3k-put-prop-test/k
@@ -1165,9 +1210,6 @@ that the second element is a symbol with the given name."
   "Chain two CPS lookups using <-. [test-only]"
   (<- value nskk--cps-test-lookup key)
   (succeed (1+ value)))
-
-(defvar nskk--cps-test-action-result nil
-  "Holds the side-effect result for defun/done functional tests.")
 
 (defun/done nskk--cps-test-action (x)
   "Side-effecting action that stores X. [test-only]"
@@ -1624,8 +1666,9 @@ that the second element is a symbol with the given name."
     (should (= (nskk-cps-test--seq-caller 3) 12)))
 
   (nskk-it "propagates failure to the outer on-not-found"
-    (defun/k nskk-cps-test--always-failed (_x)
+    (defun/k nskk-cps-test--always-failed (x)
       "Always fail."
+      (ignore x)
       (fail))
     (defun/k nskk-cps-test--seq-fail-caller (n)
       "Use <-seq; inner failure should propagate."
@@ -1635,8 +1678,9 @@ that the second element is a symbol with the given name."
     (should (null (nskk-cps-test--seq-fail-caller 99))))
 
   (nskk-it "body is not reached when CPS call fails"
-    (defun/k nskk-cps-test--always-failed (_x)
+    (defun/k nskk-cps-test--always-failed (x)
       "Always fail."
+      (ignore x)
       (fail))
     (let ((body-reached nil))
       (defun/k nskk-cps-test--seq-side-effect-caller (n)

--- a/test/unit/nskk-debug-test.el
+++ b/test/unit/nskk-debug-test.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'subr-x)
 (require 'nskk-debug)
 (require 'nskk-test-framework)
 (require 'nskk-test-macros)
@@ -124,7 +125,7 @@
 
   (nskk-it "clears the debug buffer contents"
     (nskk-debug-test--insert-lines "[00:00:00.000] Test content")
-    (nskk-given (should (> (length (nskk-debug-test--buffer-contents)) 0)))
+    (nskk-given (should (not (string-empty-p (nskk-debug-test--buffer-contents)))))
     (nskk-when  (nskk-debug-clear))
     (nskk-then  (should (equal (nskk-debug-test--buffer-contents) ""))))
 
@@ -303,7 +304,7 @@
 
   (nskk-it "nskk--debug-timestamp-format is a non-empty string"
     (should (and (stringp nskk--debug-timestamp-format)
-                 (> (length nskk--debug-timestamp-format) 0)))))
+                 (not (string-empty-p nskk--debug-timestamp-format))))))
 
 ;;;
 ;;; PBT-001 — Timestamp format invariant
@@ -366,10 +367,10 @@
   (with-max-entries item
     (nskk-debug-test--insert-lines
      ;; Insert item+3 lines (always more than max).
-     (mapconcat #'identity
-                (cl-loop for i from 0 below (+ item 3)
-                         collect (format "[00:00:%02d.000] Entry %d" i i))
-                "\n"))
+     (string-join
+      (cl-loop for i from 0 below (+ item 3)
+               collect (format "[00:00:%02d.000] Entry %d" i i))
+      "\n"))
     (with-current-buffer (nskk--debug-buffer)
       (nskk--debug-trim))
     (let* ((raw (nskk-debug-test--buffer-contents))
@@ -422,7 +423,7 @@
     (nskk-debug-clear)
     (nskk-debug-log "%s" msg)
     (let ((contents (nskk-debug-test--buffer-contents)))
-      (and (> (length contents) 0)
+      (and (not (string-empty-p contents))
            (string-match-p "\\[[0-9]+:[0-9]+:[0-9]+\\.[0-9]+\\]" contents)
            (string-match-p (regexp-quote msg) contents))))
   50 42)

--- a/test/unit/nskk-dictionary-test.el
+++ b/test/unit/nskk-dictionary-test.el
@@ -348,7 +348,7 @@
                                (workflow-io-dict "あいうえ" ("アイウエ"))
                                (workflow-io-dict "あいうえお" ("アイウエオ"))
                                (workflow-io-dict "かきく" ("カキク")))
-      (let ((index (make-nskk-dict-index :predicate 'workflow-io-dict)))
+      (let ((_index (make-nskk-dict-index :predicate 'workflow-io-dict)))
         ;; Verify prefix search works
         (let ((results (nskk-prolog-trie-prefix-search 'workflow-io-dict 2 "あいう")))
           (should (= (length results) 3))
@@ -395,12 +395,15 @@
         (should (cl-some (lambda (p) (string-match-p "profiles/default" p)) result))))))
 
 (nskk-describe "ja-dic conversion"
+  ;; Mock tree nodes store candidates in the order produced by
+  ;; `skkdic-extract-conversion-data' (cons-reversal of ja-dic.el text order).
+  ;; nskk passes them through as-is, matching DDSKK's candidate presentation order.
   (nskk-it "decodes and flattens okuri-nasi entries"
     (let* ((o (- (logand (encode-char ?お 'japanese-jisx0208) #xFF) 32))
            (sample `(skdic-okuri-nasi
                      (,o ("緒" "小")))))
       (should (equal (nskk--dict-ja-dic-flatten-tree sample)
-                     '(("お" . ("小" "緒")))))))
+                     '(("お" . ("緒" "小")))))))
 
   (nskk-it "decodes and flattens okuri-ari entries"
     (let* ((wa (- (logand (encode-char ?わ 'japanese-jisx0208) #xFF) 32))
@@ -410,7 +413,7 @@
                           (,ru t
                                (-105 ("惡" "悪")))))))
       (should (equal (nskk--dict-ja-dic-flatten-tree sample)
-                     '(("わるi" . ("悪" "惡")))))))
+                     '(("わるi" . ("惡" "悪")))))))
 
   (nskk-it "loads flattened ja-dic entries into system-dict-entry"
     (nskk-prolog-test-with-isolated-db
@@ -425,9 +428,9 @@
                                            (-105 ("惡" "悪")))))))
         (nskk-with-mocks ((load-library (lambda (_feature) t)))
           (should (eq 'system (nskk-dict-load-ja-dic)))
-          (should (equal '("小" "緒")
+          (should (equal '("緒" "小")
                          (nskk-prolog-query-value '(system-dict-entry "お" \?c) '\?c)))
-          (should (equal '("悪" "惡")
+          (should (equal '("惡" "悪")
                          (nskk-prolog-query-value '(system-dict-entry "わるi" \?c) '\?c))))))))
 
 (nskk-describe "dict-initialize"
@@ -1322,6 +1325,110 @@
       ;; No duplicate entries for the registered word
       (= (cl-count word result :test #'equal) 1)))
   30 42)
+
+;;;; nskk-dict-load-kakutei-dictionary tests
+
+(defmacro nskk-test-with-kakutei-file (entries &rest body)
+  "Execute BODY with a temp SKK file containing ENTRIES loaded as kakutei dict.
+ENTRIES is a list of (reading . (candidate1 candidate2 ...)) cons cells.
+The file is written in SKK-JISYO format, loaded, and cleaned up after BODY."
+  (declare (indent 1))
+  `(nskk-prolog-test-with-isolated-db
+     (let* ((tmpfile (make-temp-file "nskk-test-kakutei-" nil ".jisyo"))
+            (nskk-kakutei-jisyo tmpfile)
+            (nskk--kakutei-dict-loaded nil))
+       (unwind-protect
+           (progn
+             (with-temp-file tmpfile
+               (insert ";; -*- coding: utf-8 -*-\n")
+               (insert ";; okuri-nasi entries.\n")
+               (dolist (e ,entries)
+                 (insert (car e) " /"
+                         (string-join (cdr e) "/")
+                         "/\n")))
+             ,@body)
+         (when (file-exists-p tmpfile)
+           (delete-file tmpfile))
+         (nskk-prolog-retract-all 'kakutei-dict-entry 2)
+         (setq nskk--kakutei-dict-loaded nil)))))
+
+(nskk-describe "nskk-dict-load-kakutei-dictionary"
+  (nskk-it "returns nil when nskk-kakutei-jisyo is nil"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk-kakutei-jisyo nil)
+            (nskk--kakutei-dict-loaded nil))
+        (should (null (nskk-dict-load-kakutei-dictionary))))))
+
+  (nskk-it "returns nil when file does not exist"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk-kakutei-jisyo "/nonexistent/path/kakutei.jisyo")
+            (nskk--kakutei-dict-loaded nil))
+        (should (null (nskk-dict-load-kakutei-dictionary))))))
+
+  (nskk-it "returns 'kakutei when file exists and has entries"
+    (nskk-test-with-kakutei-file '(("てすと" "テスト"))
+      (should (eq (nskk-dict-load-kakutei-dictionary) 'kakutei))))
+
+  (nskk-it "sets nskk--kakutei-dict-loaded to t after loading"
+    (nskk-test-with-kakutei-file '(("てすと" "テスト"))
+      (nskk-dict-load-kakutei-dictionary)
+      (should nskk--kakutei-dict-loaded)))
+
+  (nskk-it "makes entries queryable after load"
+    (nskk-test-with-kakutei-file '(("てすと" "テスト"))
+      (nskk-dict-load-kakutei-dictionary)
+      (let ((result (nskk-prolog-query-value
+                     '(kakutei-dict-entry "てすと" \?c) '\?c)))
+        (should result)
+        (should (member "テスト" result))))))
+
+;;;; nskk-dict-lookup-kakutei/k tests
+
+(nskk-describe "nskk-dict-lookup-kakutei/k"
+  (nskk-it "calls on-not-found when nskk--kakutei-dict-loaded is nil"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--kakutei-dict-loaded nil)
+            (not-found nil))
+        (nskk-dict-lookup-kakutei/k "てすと"
+                                  (lambda (_) nil)
+                                  (lambda () (setq not-found t)))
+        (should not-found))))
+
+  (nskk-it "calls on-not-found for non-string reading"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--kakutei-dict-loaded t)
+            (not-found nil))
+        (nskk-dict-lookup-kakutei/k nil
+                                  (lambda (_) nil)
+                                  (lambda () (setq not-found t)))
+        (should not-found))))
+
+  (nskk-it "calls on-found with single candidate when unique match"
+    (nskk-test-with-kakutei-file '(("てすと" "テスト"))
+      (nskk-dict-load-kakutei-dictionary)
+      (let ((found nil))
+        (nskk-dict-lookup-kakutei/k "てすと"
+                                  (lambda (c) (setq found c))
+                                  #'ignore)
+        (should (equal found "テスト")))))
+
+  (nskk-it "calls on-not-found when entry has multiple candidates"
+    (nskk-test-with-kakutei-file '(("かんじ" "漢字" "感じ"))
+      (nskk-dict-load-kakutei-dictionary)
+      (let ((not-found nil))
+        (nskk-dict-lookup-kakutei/k "かんじ"
+                                  (lambda (_) nil)
+                                  (lambda () (setq not-found t)))
+        (should not-found))))
+
+  (nskk-it "calls on-not-found for unknown reading"
+    (nskk-test-with-kakutei-file '(("てすと" "テスト"))
+      (nskk-dict-load-kakutei-dictionary)
+      (let ((not-found nil))
+        (nskk-dict-lookup-kakutei/k "ぜんぜんない"
+                                  (lambda (_) nil)
+                                  (lambda () (setq not-found t)))
+        (should not-found)))))
 
 (provide 'nskk-dictionary-test)
 

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -869,7 +869,7 @@
                         (nskk-dict-register-word #'ignore))
         (nskk-start-registration "てすと")
         (should prompt-shown)
-        (should (string-match "辞書登録" prompt-shown))))))
+        (should (string-match-p "辞書登録" prompt-shown))))))
 
 ;;;
 ;;; Seeded Property-Based Tests
@@ -2181,7 +2181,7 @@
         (nskk-state-set-candidates nskk-current-state '("X" "Y"))
         (nskk-state-force-henkan-phase nskk-current-state 'active)
         (nskk-with-mocks ((run-hook-with-args
-                           (lambda (hook &rest args) (setq captured-args args))))
+                           (lambda (_hook &rest args) (setq captured-args args))))
           (nskk--wrap-to-first-candidate))
         (should (equal (car captured-args) '("X" "Y")))
         (should (= (cadr captured-args) 0))))))
@@ -2922,7 +2922,7 @@
       (let ((nskk-current-state (nskk-state-create 'katakana))
             (nskk--romaji-buffer "")
             (nskk--pending-romaji-overlay nil)
-            inserted-text)
+            _inserted-text)
         (nskk-with-mocks
             ((nskk-convert-input-to-kana-final/k
               (lambda (cont _ignored) (funcall cont "う")))
@@ -3036,7 +3036,7 @@
       (let ((nskk--input-initialized nil)
             (nskk--state-prolog-initialized nil)
             (nskk--henkan-initialized nil)
-            (nskk-kana--initialized nil)
+            (nskk--kana-initialized nil)
             (nskk--converter-initialized nil)
             (nskk--candidate-key-facts-initialized nil))
         (with-temp-buffer
@@ -3808,6 +3808,156 @@
           (set-marker nskk--conversion-start-marker (point-min))
           (insert nskk-henkan-on-marker (char-to-string ch))
           (should (nskk--preedit-ends-with-plain-vowel-p)))))))
+
+;;;
+;;; SKK Numeric Conversion (数値変換)
+;;;
+
+(nskk-describe "nskk--numeric-parse-reading"
+  (nskk-it "parses single-digit reading into num-str and base-key"
+    (should (equal (nskk--numeric-parse-reading "#1ko") '("1" . "#ko"))))
+
+  (nskk-it "parses multi-digit reading"
+    (should (equal (nskk--numeric-parse-reading "#123ji") '("123" . "#ji"))))
+
+  (nskk-it "parses two-digit reading with suffix"
+    (should (equal (nskk--numeric-parse-reading "#10ko") '("10" . "#ko"))))
+
+  (nskk-it "returns nil when no # prefix"
+    (should (null (nskk--numeric-parse-reading "1ko"))))
+
+  (nskk-it "returns nil for plain kana reading"
+    (should (null (nskk--numeric-parse-reading "こ"))))
+
+  (nskk-it "returns nil when # has no following digits"
+    (should (null (nskk--numeric-parse-reading "#ko")))))
+
+(nskk-describe "nskk--numeric-to-kanji"
+  (nskk-deftest-table numeric-to-kanji
+    :description "Each digit converts to its kanji equivalent"
+    :columns (input expected)
+    :rows (("0" "〇")
+           ("1" "一")
+           ("5" "五")
+           ("9" "九")
+           ("10" "一〇")
+           ("12" "一二")
+           ("1024" "一〇二四")
+           ("9999" "九九九九"))
+    :body (should (equal (nskk--numeric-to-kanji input) expected))))
+
+(nskk-describe "nskk--numeric-to-fullwidth"
+  (nskk-deftest-table numeric-to-fullwidth
+    :description "Each digit shifts to full-width Unicode range"
+    :columns (input expected)
+    :rows (("0" "０")
+           ("1" "１")
+           ("9" "９")
+           ("123" "１２３")
+           ("1024" "１０２４"))
+    :body (should (equal (nskk--numeric-to-fullwidth input) expected))))
+
+(nskk-describe "nskk--n-to-kanji-place"
+  (nskk-it "converts single-digit integers"
+    (should (equal (nskk--n-to-kanji-place 1) "一"))
+    (should (equal (nskk--n-to-kanji-place 9) "九")))
+
+  (nskk-it "drops leading 一 for 十 (10 → 十 not 一十)"
+    (should (equal (nskk--n-to-kanji-place 10) "十")))
+
+  (nskk-it "produces correct tens with remainder"
+    (should (equal (nskk--n-to-kanji-place 11) "十一"))
+    (should (equal (nskk--n-to-kanji-place 20) "二十"))
+    (should (equal (nskk--n-to-kanji-place 21) "二十一")))
+
+  (nskk-it "drops leading 一 for 百 (100 → 百 not 一百)"
+    (should (equal (nskk--n-to-kanji-place 100) "百")))
+
+  (nskk-it "produces correct hundreds"
+    (should (equal (nskk--n-to-kanji-place 101) "百一"))
+    (should (equal (nskk--n-to-kanji-place 200) "二百"))
+    (should (equal (nskk--n-to-kanji-place 110) "百十")))
+
+  (nskk-it "drops leading 一 for 千 (1000 → 千 not 一千)"
+    (should (equal (nskk--n-to-kanji-place 1000) "千")))
+
+  (nskk-it "produces correct thousands"
+    (should (equal (nskk--n-to-kanji-place 1001) "千一"))
+    (should (equal (nskk--n-to-kanji-place 2000) "二千"))
+    (should (equal (nskk--n-to-kanji-place 1024) "千二十四")))
+
+  (nskk-it "keeps leading 一 for 万 (10000 → 一万)"
+    (should (equal (nskk--n-to-kanji-place 10000) "一万")))
+
+  (nskk-it "produces correct ten-thousands"
+    (should (equal (nskk--n-to-kanji-place 20000) "二万"))
+    (should (equal (nskk--n-to-kanji-place 12345) "一万二千三百四十五"))))
+
+(nskk-describe "nskk--numeric-to-place-values"
+  (nskk-it "handles zero as special case 〇"
+    (should (equal (nskk--numeric-to-place-values "0") "〇")))
+
+  (nskk-deftest-table numeric-to-place-values
+    :description "Converts number string to kanji place values"
+    :columns (input expected)
+    :rows (("1"     "一")
+           ("10"    "十")
+           ("100"   "百")
+           ("1000"  "千")
+           ("1024"  "千二十四")
+           ("10000" "一万"))
+    :body (should (equal (nskk--numeric-to-place-values input) expected))))
+
+(nskk-describe "nskk--numeric-convert"
+  (nskk-deftest-table numeric-convert-dispatch
+    :description "Dispatches on type code to correct conversion"
+    :columns (type input expected)
+    :rows ((0 "42" "42")         ; #0 = literal (no change)
+           (1 "42" "４２")       ; #1 = full-width
+           (2 "42" "四二")       ; #2 = kanji digit-by-digit
+           (3 "42" "四十二")     ; #3 = kanji place values
+           (4 "42" "四二")       ; #4 = same as #2
+           (8 "42" "42")         ; #8 falls through to literal
+           (9 "42" "42"))        ; unknown type falls through to literal
+    :body (should (equal (nskk--numeric-convert input type) expected)))
+
+  (nskk-it "type 2 and type 4 produce identical output"
+    (should (equal (nskk--numeric-convert "1024" 2)
+                   (nskk--numeric-convert "1024" 4)))))
+
+(nskk-describe "nskk--numeric-process-candidate"
+  (nskk-it "replaces single #N pattern in template"
+    (should (equal (nskk--numeric-process-candidate "第#3時" "1") "第一時")))
+
+  (nskk-it "replaces #0 pattern as literal"
+    (should (equal (nskk--numeric-process-candidate "#0個" "42") "42個")))
+
+  (nskk-it "replaces #1 pattern as full-width"
+    (should (equal (nskk--numeric-process-candidate "#1時" "3") "３時")))
+
+  (nskk-it "replaces #2 pattern as kanji digit-by-digit"
+    (should (equal (nskk--numeric-process-candidate "#2個" "10") "一〇個")))
+
+  (nskk-it "replaces #3 pattern as kanji place values"
+    (should (equal (nskk--numeric-process-candidate "#3個" "10") "十個")))
+
+  (nskk-it "leaves template unchanged when no #N pattern present"
+    (should (equal (nskk--numeric-process-candidate "そのまま" "42") "そのまま")))
+
+  (nskk-it "replaces multiple #N patterns in a single candidate"
+    (should (equal (nskk--numeric-process-candidate "#1と#2" "5") "５と五"))))
+
+(nskk-describe "nskk--numeric-process-candidates"
+  (nskk-it "processes a list of candidates with the same num-str"
+    (should (equal (nskk--numeric-process-candidates '("#0個" "#2個") "10")
+                   '("10個" "一〇個"))))
+
+  (nskk-it "processes mixed-type candidate list"
+    (should (equal (nskk--numeric-process-candidates '("#0個" "#2個" "#3個") "10")
+                   '("10個" "一〇個" "十個"))))
+
+  (nskk-it "returns empty list for empty candidate list"
+    (should (equal (nskk--numeric-process-candidates '() "42") '()))))
 
 (provide 'nskk-henkan-test)
 

--- a/test/unit/nskk-inline-test.el
+++ b/test/unit/nskk-inline-test.el
@@ -1,0 +1,184 @@
+;;; nskk-inline-test.el --- Tests for nskk-inline.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 NSKK Authors
+
+;; Author: takeokunn <bararararatty@gmail.com>
+;; Keywords: japanese, input, test
+
+;; This file is part of NSKK.
+
+;;; Commentary:
+
+;; Tests for nskk-inline.el covering:
+;; - Function existence (fboundp)
+;; - Customization variables (nskk-show-inline)
+;; - Face definitions
+;; - nskk--inline-build-horizontal: propertized string, nskk-inline-face
+;; - nskk--inline-build-vertical: starts with newline, nskk-inline-face
+;; - nskk-inline-show-candidate: no-op when nskk-show-inline is nil
+;; - nskk-inline-show-candidate: no-op for empty/nil candidate
+;; - nskk-inline-hide: safe when overlay is nil
+;; - nskk-inline-show-registration-badge: no-op when nskk-show-inline is nil
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'nskk-inline)
+(require 'nskk-state)
+(require 'nskk-test-framework)
+(require 'nskk-test-macros)
+
+;;;; Function Existence
+
+(nskk-describe "nskk-inline function existence"
+  (nskk-it "nskk-inline-show-candidate is defined"
+    (should (fboundp 'nskk-inline-show-candidate)))
+  (nskk-it "nskk-inline-hide is defined"
+    (should (fboundp 'nskk-inline-hide)))
+  (nskk-it "nskk-inline-show-registration-badge is defined"
+    (should (fboundp 'nskk-inline-show-registration-badge)))
+  (nskk-it "nskk--inline-anchor is defined"
+    (should (fboundp 'nskk--inline-anchor)))
+  (nskk-it "nskk--inline-build-horizontal is defined"
+    (should (fboundp 'nskk--inline-build-horizontal)))
+  (nskk-it "nskk--inline-build-vertical is defined"
+    (should (fboundp 'nskk--inline-build-vertical))))
+
+;;;; Customization Variables
+
+(nskk-describe "nskk-inline customization variables"
+  (nskk-it "nskk-show-inline is defined"
+    (should (boundp 'nskk-show-inline)))
+  (nskk-it "nskk-show-inline defaults to nil"
+    (should (null nskk-show-inline))))
+
+;;;; Face Definitions
+
+(nskk-describe "nskk-inline faces"
+  (nskk-it "nskk-inline-face is defined"
+    (should (facep 'nskk-inline-face)))
+  (nskk-it "nskk-jisyo-registration-badge-face is defined"
+    (should (facep 'nskk-jisyo-registration-badge-face))))
+
+;;;; Build Helpers
+
+(nskk-describe "nskk--inline-build-horizontal"
+  (nskk-it "returns a string"
+    (should (stringp (nskk--inline-build-horizontal "候補"))))
+  (nskk-it "contains the candidate text"
+    (should (string-match-p "候補" (nskk--inline-build-horizontal "候補"))))
+  (nskk-it "starts with a space separator"
+    (should (string-prefix-p " " (nskk--inline-build-horizontal "候補"))))
+  (nskk-it "applies nskk-inline-face"
+    (let ((result (nskk--inline-build-horizontal "test")))
+      (should (eq (get-text-property 0 'face result) 'nskk-inline-face)))))
+
+(nskk-describe "nskk--inline-build-vertical"
+  (nskk-it "returns a string"
+    (should (stringp (nskk--inline-build-vertical "候補"))))
+  (nskk-it "contains the candidate text"
+    (should (string-match-p "候補" (nskk--inline-build-vertical "候補"))))
+  (nskk-it "starts with a newline"
+    (should (string-prefix-p "\n" (nskk--inline-build-vertical "候補"))))
+  (nskk-it "applies nskk-inline-face"
+    (let ((result (nskk--inline-build-vertical "test")))
+      (should (eq (get-text-property 0 'face result) 'nskk-inline-face)))))
+
+;;;; Anchor
+
+(nskk-describe "nskk--inline-anchor"
+  (nskk-it "returns point when conversion overlay is nil"
+    (with-temp-buffer
+      (insert "abc")
+      (goto-char 2)
+      (let ((nskk--conversion-overlay nil))
+        (should (= (nskk--inline-anchor) (point)))))))
+
+;;;; Show Candidate Guards
+
+(nskk-describe "nskk-inline-show-candidate"
+  (nskk-it "is a no-op when nskk-show-inline is nil"
+    (with-temp-buffer
+      (let ((nskk-show-inline nil)
+            (nskk--inline-overlay nil))
+        (nskk-inline-show-candidate "候補")
+        (should (null nskk--inline-overlay)))))
+
+  (nskk-it "is a no-op for nil candidate"
+    (with-temp-buffer
+      (let ((nskk-show-inline t)
+            (nskk--inline-overlay nil))
+        (nskk-inline-show-candidate nil)
+        (should (null nskk--inline-overlay)))))
+
+  (nskk-it "is a no-op for empty string candidate"
+    (with-temp-buffer
+      (let ((nskk-show-inline t)
+            (nskk--inline-overlay nil))
+        (nskk-inline-show-candidate "")
+        (should (null nskk--inline-overlay)))))
+
+  (nskk-it "creates overlay when nskk-show-inline is t"
+    (with-temp-buffer
+      (insert "あ")
+      (let ((nskk-show-inline t)
+            (nskk--inline-overlay nil)
+            (nskk--conversion-overlay nil))
+        (nskk-inline-show-candidate "亜")
+        (unwind-protect
+            (should (overlayp nskk--inline-overlay))
+          (nskk-delete-overlay nskk--inline-overlay)))))
+
+  (nskk-it "creates overlay when nskk-show-inline is vertical"
+    (with-temp-buffer
+      (insert "あ")
+      (let ((nskk-show-inline 'vertical)
+            (nskk--inline-overlay nil)
+            (nskk--conversion-overlay nil))
+        (nskk-inline-show-candidate "亜")
+        (unwind-protect
+            (should (overlayp nskk--inline-overlay))
+          (nskk-delete-overlay nskk--inline-overlay))))))
+
+;;;; Hide
+
+(nskk-describe "nskk-inline-hide"
+  (nskk-it "is safe to call when overlay is nil"
+    (with-temp-buffer
+      (let ((nskk--inline-overlay nil))
+        (should-not (condition-case err
+                        (progn (nskk-inline-hide) nil)
+                      (error err))))))
+
+  (nskk-it "deletes existing overlay"
+    (with-temp-buffer
+      (insert "あ")
+      (let ((nskk--inline-overlay (make-overlay 1 1)))
+        (nskk-inline-hide)
+        (should (null nskk--inline-overlay))))))
+
+;;;; Registration Badge
+
+(nskk-describe "nskk-inline-show-registration-badge"
+  (nskk-it "is a no-op when nskk-show-inline is nil"
+    (with-temp-buffer
+      (let ((nskk-show-inline nil)
+            (nskk--inline-overlay nil))
+        (nskk-inline-show-registration-badge)
+        (should (null nskk--inline-overlay)))))
+
+  (nskk-it "creates overlay when nskk-show-inline is t"
+    (with-temp-buffer
+      (insert "あ")
+      (let ((nskk-show-inline t)
+            (nskk--inline-overlay nil)
+            (nskk--conversion-overlay nil))
+        (nskk-inline-show-registration-badge)
+        (unwind-protect
+            (should (overlayp nskk--inline-overlay))
+          (nskk-delete-overlay nskk--inline-overlay))))))
+
+(provide 'nskk-inline-test)
+
+;;; nskk-inline-test.el ends here

--- a/test/unit/nskk-input-test.el
+++ b/test/unit/nskk-input-test.el
@@ -907,7 +907,7 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
 ;; so (> (length input) 0) is always true; we return t on success and nil on error.
 (nskk-property-test-seeded input-pbt-romaji-char-no-crash-hiragana-mode
   ((input romaji-string))
-  (if (> (length input) 0)
+  (if (not (string-empty-p input))
       (let ((char (aref input 0)))
         (condition-case nil
             (let ((nskk--romaji-buffer ""))
@@ -1708,7 +1708,7 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
-        (let ((start-pt (point)))
+        (let ((_start-pt (point)))
           (nskk-without-modification
             (nskk--activate-preedit-mode))
           (should (nskk--conversion-start-active-p)))))))

--- a/test/unit/nskk-isearch-test.el
+++ b/test/unit/nskk-isearch-test.el
@@ -1,0 +1,207 @@
+;;; nskk-isearch-test.el --- Tests for nskk-isearch.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 NSKK Authors
+
+;; Author: takeokunn <bararararatty@gmail.com>
+;; Keywords: japanese, input, test
+
+;; This file is part of NSKK.
+
+;;; Commentary:
+
+;; Tests for nskk-isearch.el covering:
+;; - Function existence (fboundp)
+;; - nskk-isearch-mode-string-alist customization
+;; - nskk--isearch-mode-string for each NSKK mode
+;; - nskk-isearch-setup/teardown hook registration
+;; - Internal state management
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'nskk-isearch)
+(require 'nskk-state)
+(require 'nskk-prolog)
+(require 'nskk-test-framework)
+(require 'nskk-test-macros)
+
+;;;; Function Existence
+
+(nskk-describe "nskk-isearch function existence"
+  (nskk-it "nskk-isearch-setup is defined"
+    (should (fboundp 'nskk-isearch-setup)))
+  (nskk-it "nskk-isearch-teardown is defined"
+    (should (fboundp 'nskk-isearch-teardown)))
+  (nskk-it "nskk--isearch-mode-string is defined"
+    (should (fboundp 'nskk--isearch-mode-string)))
+  (nskk-it "nskk--isearch-prompt-advice is defined"
+    (should (fboundp 'nskk--isearch-prompt-advice))))
+
+;;;; Customization
+
+(nskk-describe "nskk-isearch-mode-string-alist"
+  (nskk-it "is an alist"
+    (should (listp nskk-isearch-mode-string-alist)))
+  (nskk-it "has entry for hiragana"
+    (should (assq 'hiragana nskk-isearch-mode-string-alist)))
+  (nskk-it "has entry for katakana"
+    (should (assq 'katakana nskk-isearch-mode-string-alist)))
+  (nskk-it "has entry for ascii"
+    (should (assq 'ascii nskk-isearch-mode-string-alist)))
+  (nskk-it "has entry for jisx0208-latin"
+    (should (assq 'jisx0208-latin nskk-isearch-mode-string-alist)))
+  (nskk-it "all entries have string values"
+    (dolist (entry nskk-isearch-mode-string-alist)
+      (should (stringp (cdr entry))))))
+
+;;;; Mode String Lookup
+
+(nskk-describe "nskk--isearch-mode-string with no orig-buffer"
+  (nskk-it "returns nil when orig-buffer is nil"
+    (let ((nskk--isearch-orig-buffer nil))
+      (should (null (nskk--isearch-mode-string))))))
+
+(nskk-describe "nskk--isearch-mode-string with dead buffer"
+  (nskk-it "returns nil for dead buffer"
+    (let ((buf (generate-new-buffer " *nskk-test-dead*")))
+      (kill-buffer buf)
+      (let ((nskk--isearch-orig-buffer buf))
+        (should (null (nskk--isearch-mode-string)))))))
+
+(nskk-describe "nskk--isearch-mode-string with live buffer"
+  (nskk-it "returns nil when nskk-current-state is nil in orig-buffer"
+    (nskk-prolog-test-with-isolated-db
+      (with-temp-buffer
+        (let ((nskk-current-state nil)
+              (nskk--isearch-orig-buffer (current-buffer)))
+          (should (null (nskk--isearch-mode-string)))))))
+
+  (nskk-it "returns hiragana indicator string for hiragana mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'hiragana))
+        (let ((nskk--isearch-orig-buffer (current-buffer)))
+          (let ((result (nskk--isearch-mode-string)))
+            (should (stringp result))
+            (should (equal result (cdr (assq 'hiragana nskk-isearch-mode-string-alist)))))))))
+
+  (nskk-it "returns katakana indicator for katakana mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'katakana))
+        (let ((nskk--isearch-orig-buffer (current-buffer)))
+          (let ((result (nskk--isearch-mode-string)))
+            (should (equal result (cdr (assq 'katakana nskk-isearch-mode-string-alist)))))))))
+
+  (nskk-it "returns ascii indicator for ascii mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'ascii))
+        (let ((nskk--isearch-orig-buffer (current-buffer)))
+          (let ((result (nskk--isearch-mode-string)))
+            (should (equal result (cdr (assq 'ascii nskk-isearch-mode-string-alist)))))))))
+
+  (nskk-it "returns jisx0208-latin indicator for jisx0208-latin mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'jisx0208-latin))
+        (let ((nskk--isearch-orig-buffer (current-buffer)))
+          (let ((result (nskk--isearch-mode-string)))
+            (should (equal result (cdr (assq 'jisx0208-latin nskk-isearch-mode-string-alist)))))))))
+
+  (nskk-it "returns abbrev indicator for abbrev mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'abbrev))
+        (let ((nskk--isearch-orig-buffer (current-buffer)))
+          (let ((result (nskk--isearch-mode-string)))
+            (should (equal result (cdr (assq 'abbrev nskk-isearch-mode-string-alist))))))))))
+
+;;;; Prompt Advice
+
+(nskk-describe "nskk--isearch-prompt-advice"
+  (nskk-it "returns orig-prompt unchanged when nskk-isearch-enable is nil"
+    (let ((nskk-isearch-enable nil)
+          (nskk--isearch-orig-buffer nil))
+      (let ((result (nskk--isearch-prompt-advice (lambda () "I-search: "))))
+        (should (equal result "I-search: ")))))
+
+  (nskk-it "returns orig-prompt unchanged when no mode string available"
+    (let ((nskk-isearch-enable t)
+          (nskk--isearch-orig-buffer nil))
+      (let ((result (nskk--isearch-prompt-advice (lambda () "I-search: "))))
+        (should (equal result "I-search: ")))))
+
+  (nskk-it "prepends mode string to orig-prompt when mode is active"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'hiragana))
+        (let ((nskk-isearch-enable t)
+              (nskk--isearch-orig-buffer (current-buffer)))
+          (let ((result (nskk--isearch-prompt-advice (lambda () "I-search: "))))
+            (should (stringp result))
+            (should (string-prefix-p "[か]" result))
+            (should (string-suffix-p "I-search: " result))))))))
+
+;;;; Setup / Teardown
+
+(nskk-describe "nskk-isearch-setup"
+  (nskk-it "adds hook to isearch-mode-hook"
+    (unwind-protect
+        (progn
+          (nskk-isearch-setup)
+          (should (memq #'nskk--isearch-setup isearch-mode-hook)))
+      (nskk-isearch-teardown)))
+  (nskk-it "adds hook to isearch-mode-end-hook"
+    (unwind-protect
+        (progn
+          (nskk-isearch-setup)
+          (should (memq #'nskk--isearch-teardown isearch-mode-end-hook)))
+      (nskk-isearch-teardown)))
+  (nskk-it "installs advice on isearch-message-prefix"
+    (unwind-protect
+        (progn
+          (nskk-isearch-setup)
+          (should (advice-member-p #'nskk--isearch-prompt-advice 'isearch-message-prefix)))
+      (nskk-isearch-teardown))))
+
+(nskk-describe "nskk-isearch-teardown"
+  (nskk-it "removes isearch-mode-hook"
+    (nskk-isearch-setup)
+    (nskk-isearch-teardown)
+    (should-not (memq #'nskk--isearch-setup isearch-mode-hook)))
+  (nskk-it "removes isearch-mode-end-hook"
+    (nskk-isearch-setup)
+    (nskk-isearch-teardown)
+    (should-not (memq #'nskk--isearch-teardown isearch-mode-end-hook)))
+  (nskk-it "removes advice from isearch-message-prefix"
+    (nskk-isearch-setup)
+    (nskk-isearch-teardown)
+    (should-not (advice-member-p #'nskk--isearch-prompt-advice 'isearch-message-prefix))))
+
+;;;; Internal Hooks
+
+(nskk-describe "nskk--isearch-setup hook"
+  (nskk-it "records current buffer as orig-buffer"
+    (with-temp-buffer
+      (let ((nskk--isearch-orig-buffer nil))
+        (nskk--isearch-setup)
+        (should (eq nskk--isearch-orig-buffer (current-buffer)))))))
+
+(nskk-describe "nskk--isearch-teardown hook"
+  (nskk-it "clears orig-buffer"
+    (with-temp-buffer
+      (setq nskk--isearch-orig-buffer (current-buffer))
+      (nskk--isearch-teardown)
+      (should (null nskk--isearch-orig-buffer)))))
+
+(provide 'nskk-isearch-test)
+
+;;; nskk-isearch-test.el ends here

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -30,7 +30,7 @@
 ;;; Nav Handler Test Helpers
 ;;;
 
-(defmacro nskk-deftest-nav-handler (key handler kbd-key arrow-key nav-fn)
+(defmacro nskk-deftest-nav-handler (_key handler kbd-key arrow-key nav-fn)
   "Generate standard tests for a commit-then-navigate key handler.
 KEY is a symbol like `ctrl-f'.  HANDLER is the command symbol.
 KBD-KEY is the kbd string (e.g. \"C-f\").  ARROW-KEY is the arrow kbd string.
@@ -719,7 +719,8 @@ NAV-FN is the fallthrough navigation command symbol (e.g. `forward-char')."
 (defun nskk-test-setup-converting (preedit candidate)
   "Setup converting mode for PREEDIT text with CANDIDATE.
 PREEDIT should already be in buffer starting at point.
-Sets conversion-start-marker at point, advances past PREEDIT, and configures state."
+Sets conversion-start-marker at point, advances past PREEDIT,
+and configures state."
   (nskk--set-conversion-start-marker (point))
   (forward-char (length preedit))
   (nskk-state-set-candidates nskk-current-state (list candidate))
@@ -1681,6 +1682,113 @@ Sets conversion-start-marker at point, advances past PREEDIT, and configures sta
       (condition-case err
           (nskk--classify-state)
         (error (ert-fail (format "Unexpected error: %s" err)))))))
+
+;;;
+;;; nskk--compute-phase Tests
+;;;
+
+(nskk-describe "nskk--compute-phase"
+  (nskk-it "returns 'converting when nskk-converting-p is true"
+    (nskk-with-mocks ((nskk-converting-p (lambda () t)))
+      (should (eq (nskk--compute-phase) 'converting))))
+
+  (nskk-it "returns 'henkan-on when state exists and conversion-start is set"
+    (let ((nskk-current-state (nskk-state-create 'hiragana)))
+      (nskk-with-mocks ((nskk-converting-p (lambda () nil))
+                        (nskk--get-conversion-start (lambda () 1)))
+        (should (eq (nskk--compute-phase) 'henkan-on)))))
+
+  (nskk-it "returns 'idle when no state"
+    (let ((nskk-current-state nil))
+      (nskk-with-mocks ((nskk-converting-p (lambda () nil)))
+        (should (eq (nskk--compute-phase) 'idle)))))
+
+  (nskk-it "returns 'idle when state exists but no conversion-start"
+    (let ((nskk-current-state (nskk-state-create 'hiragana)))
+      (nskk-with-mocks ((nskk-converting-p (lambda () nil))
+                        (nskk--get-conversion-start (lambda () nil)))
+        (should (eq (nskk--compute-phase) 'idle)))))
+
+  (nskk-it "converting takes priority over henkan-on"
+    (let ((nskk-current-state (nskk-state-create 'hiragana)))
+      (nskk-with-mocks ((nskk-converting-p (lambda () t))
+                        (nskk--get-conversion-start (lambda () 1)))
+        (should (eq (nskk--compute-phase) 'converting)))))
+
+  (nskk-it "return value is always one of the 3 known phase symbols"
+    (let ((valid '(converting henkan-on idle)))
+      (nskk-with-mocks ((nskk-converting-p (lambda () t)))
+        (should (memq (nskk--compute-phase) valid)))
+      (let ((nskk-current-state nil))
+        (nskk-with-mocks ((nskk-converting-p (lambda () nil)))
+          (should (memq (nskk--compute-phase) valid)))))))
+
+;;;
+;;; nskk--compute-text-presence Tests
+;;;
+
+(nskk-describe "nskk--compute-text-presence"
+  (nskk-it "returns 'has-text when nskk--has-preedit is true"
+    (nskk-with-mocks ((nskk--has-preedit (lambda () t)))
+      (should (eq (nskk--compute-text-presence) 'has-text))))
+
+  (nskk-it "returns 'no-text when nskk--has-preedit is false"
+    (nskk-with-mocks ((nskk--has-preedit (lambda () nil)))
+      (should (eq (nskk--compute-text-presence) 'no-text))))
+
+  (nskk-it "return value is always one of the 2 known symbols"
+    (let ((valid '(has-text no-text)))
+      (nskk-with-mocks ((nskk--has-preedit (lambda () t)))
+        (should (memq (nskk--compute-text-presence) valid)))
+      (nskk-with-mocks ((nskk--has-preedit (lambda () nil)))
+        (should (memq (nskk--compute-text-presence) valid))))))
+
+;;;
+;;; nskk--compute-mode-category Tests
+;;;
+
+(nskk-describe "nskk--compute-mode-category"
+  (nskk-it "returns 'other when nskk-current-state is nil"
+    (let ((nskk-current-state nil))
+      (should (eq (nskk--compute-mode-category) 'other))))
+
+  (nskk-it "returns 'japanese for hiragana mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((nskk-current-state (nskk-state-create 'hiragana)))
+        (should (eq (nskk--compute-mode-category) 'japanese)))))
+
+  (nskk-it "returns 'japanese for katakana mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((nskk-current-state (nskk-state-create 'katakana)))
+        (should (eq (nskk--compute-mode-category) 'japanese)))))
+
+  (nskk-it "returns 'marker-mode for abbrev mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((nskk-current-state (nskk-state-create 'abbrev)))
+        (should (eq (nskk--compute-mode-category) 'marker-mode)))))
+
+  (nskk-it "returns 'other for ascii mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((nskk-current-state (nskk-state-create 'ascii)))
+        (should (eq (nskk--compute-mode-category) 'other)))))
+
+  (nskk-it "returns 'other for jisx0208-latin mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((nskk-current-state (nskk-state-create 'jisx0208-latin)))
+        (should (eq (nskk--compute-mode-category) 'other)))))
+
+  (nskk-it "return value is always one of the 3 known category symbols"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((valid '(japanese marker-mode other)))
+        (dolist (mode '(hiragana katakana ascii abbrev jisx0208-latin))
+          (let ((nskk-current-state (nskk-state-create mode)))
+            (should (memq (nskk--compute-mode-category) valid))))))))
 
 ;;;
 ;;; Property-based invariant tests

--- a/test/unit/nskk-modeline-test.el
+++ b/test/unit/nskk-modeline-test.el
@@ -99,7 +99,7 @@
   :rows ((hiragana) (katakana) (katakana-半角) (ascii) (latin) (jisx0208-latin) (abbrev))
   :body (let ((color (nskk--cursor-with-color mode)))
           (should (stringp color))
-          (should (> (length color) 0))))
+          (should (not (string-empty-p color)))))
 
 (nskk-describe "nskk--cursor-with-color special cases"
   (nskk-it "returns nil for direct (no standalone mode-properties fact)"
@@ -197,7 +197,7 @@
             (nskk--last-cursor-color nil))
         (nskk-cursor-update)
         (should (stringp nskk--last-cursor-color))
-        (should (> (length nskk--last-cursor-color) 0)))))
+        (should (not (string-empty-p nskk--last-cursor-color))))))
 
   (nskk-it "does not re-apply cursor color when color is unchanged"
     (nskk-with-state 'hiragana
@@ -257,7 +257,7 @@
   '(hiragana katakana ascii latin jisx0208-latin abbrev)
   (let ((nskk-current-state (nskk-state-create item)))
     (and (stringp (nskk-modeline-indicator))
-         (> (length (nskk-modeline-indicator)) 0))))
+         (not (string-empty-p (nskk-modeline-indicator))))))
 
 ;;;
 ;;; PBT-002 — Format string invariant (exhaustive over all valid modes)
@@ -297,7 +297,7 @@
 (nskk-property-test-exhaustive modeline-cursor-color-all-modes-non-empty
   '(hiragana katakana katakana-半角 ascii latin jisx0208-latin abbrev)
   (let ((color (nskk--cursor-with-color item)))
-    (and (stringp color) (> (length color) 0))))
+    (and (stringp color) (not (string-empty-p color)))))
 
 (nskk-deftest-table cursor-faces-defined
   :columns (face-sym)
@@ -392,7 +392,7 @@
   (nskk-it "returns a color string for hiragana"
     (let ((color (nskk--cursor-with-color 'hiragana)))
       (should (stringp color))
-      (should (> (length color) 0))))
+      (should (not (string-empty-p color)))))
 
   (nskk-it "returns a color string for katakana"
     (let ((color (nskk--cursor-with-color 'katakana)))

--- a/test/unit/nskk-program-dictionary-test.el
+++ b/test/unit/nskk-program-dictionary-test.el
@@ -876,11 +876,11 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
   (nskk-context "format validation"
     (nskk-it "first candidate matches YYYY/MM/DD(WeekAbbrev) pattern"
       (let ((cand1 (car (nskk--program-dict-today "today"))))
-        (should (string-match "\\`[0-9]\\{4\\}/[0-9]\\{2\\}/[0-9]\\{2\\}(\\(?:Sun\\|Mon\\|Tue\\|Wed\\|Thu\\|Fri\\|Sat\\))\\'" cand1))))
+        (should (string-match-p "\\`[0-9]\\{4\\}/[0-9]\\{2\\}/[0-9]\\{2\\}(\\(?:Sun\\|Mon\\|Tue\\|Wed\\|Thu\\|Fri\\|Sat\\))\\'" cand1))))
 
     (nskk-it "second candidate matches YYYY年MM月DD日(WeekKanji) pattern"
       (let ((cand2 (cadr (nskk--program-dict-today "today"))))
-        (should (string-match "\\`[0-9]\\{4\\}年[0-9]\\{2\\}月[0-9]\\{2\\}日([日月火水木金土])\\'" cand2))))
+        (should (string-match-p "\\`[0-9]\\{4\\}年[0-9]\\{2\\}月[0-9]\\{2\\}日([日月火水木金土])\\'" cand2))))
 
     (nskk-it "year in first candidate is a 4-digit number > 2000"
       (let ((cand1 (car (nskk--program-dict-today "today"))))
@@ -922,11 +922,11 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
   (nskk-context "format validation"
     (nskk-it "first candidate matches HH:MM:SS pattern"
       (let ((cand1 (car (nskk--program-dict-now "now"))))
-        (should (string-match "\\`[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\'" cand1))))
+        (should (string-match-p "\\`[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\'" cand1))))
 
     (nskk-it "second candidate matches HH時MM分SS秒 pattern"
       (let ((cand2 (cadr (nskk--program-dict-now "now"))))
-        (should (string-match "\\`[0-9]\\{2\\}時[0-9]\\{2\\}分[0-9]\\{2\\}秒\\'" cand2))))
+        (should (string-match-p "\\`[0-9]\\{2\\}時[0-9]\\{2\\}分[0-9]\\{2\\}秒\\'" cand2))))
 
     (nskk-it "hour in first candidate is in range 00-23"
       (let* ((cand1 (car (nskk--program-dict-now "now")))
@@ -1034,7 +1034,7 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
           (lambda (v) (setq found-arg v))
           #'ignore))
       (should (listp found-arg))
-      (should (> (length found-arg) 0))))
+      (should found-arg)))
 
   (nskk-it "calls on-found for 'now'"
     (let ((found-arg nil))
@@ -1043,7 +1043,7 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
           (lambda (v) (setq found-arg v))
           #'ignore))
       (should (listp found-arg))
-      (should (> (length found-arg) 0))))
+      (should found-arg)))
 
   (nskk-it "calls on-found for '=1+1'"
     (let ((found-arg nil))
@@ -1052,7 +1052,7 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
           (lambda (v) (setq found-arg v))
           #'ignore))
       (should (listp found-arg))
-      (should (> (length found-arg) 0))))
+      (should found-arg)))
 
   (nskk-it "returns candidates from today handler"
     (nskk--pd-builtin-test-with-env t
@@ -1158,7 +1158,7 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
            (cand2  (cadr result))
            (sec1   (string-to-number (substring cand1 6 8))))
       ;; HH:MM:SS and HH時MM分SS秒 share the same second
-      (should (string-match (format "%02d秒" sec1) cand2)))))
+      (should (string-match-p (format "%02d秒" sec1) cand2)))))
 
 ;;; ─────────────────────────────────────────────────────────────────────────
 ;;; nskk--program-dict-calculate: floating point and custom (S-3/S-4/S-5)

--- a/test/unit/nskk-prolog-test.el
+++ b/test/unit/nskk-prolog-test.el
@@ -201,6 +201,75 @@
       (should-not (nskk--prolog-fail-p '())))))
 
 ;;;;
+;;;; 3b. nskk-prolog-unify/k — CPS interface
+;;;;
+
+(nskk-describe "nskk-prolog-unify/k CPS interface"
+  (nskk-context "on-found path"
+    (nskk-it "calls on-found with original subst for equal atoms"
+      (let ((found nil) (not-found nil))
+        (nskk-prolog-unify/k 'a 'a nil
+                             (lambda (s) (setq found s))
+                             (lambda () (setq not-found t)))
+        (should-not not-found)
+        (should (eq found nil))))
+
+    (nskk-it "calls on-found with extended subst when binding a variable"
+      (let ((found nil))
+        (nskk-prolog-unify/k '\?x 42 nil
+                             (lambda (s) (setq found s))
+                             #'ignore)
+        (should found)
+        (should (equal (nskk-prolog-walk '\?x found) 42))))
+
+    (nskk-it "calls on-found for anonymous character (skips binding)"
+      ;; The integer ?_ (char 95) is treated as anonymous by nskk--prolog-anonymous-p
+      (let ((found nil))
+        (nskk-prolog-unify/k ?_ 'something nil
+                             (lambda (s) (setq found s))
+                             #'ignore)
+        (should (eq found nil))))  ; subst unchanged — no binding added
+
+    (nskk-it "calls on-found for recursive list unification with bindings"
+      (let ((found nil))
+        (nskk-prolog-unify/k '(a \?x) '(a 1) nil
+                             (lambda (s) (setq found s))
+                             #'ignore)
+        (should found)
+        (should (equal (nskk-prolog-walk '\?x found) 1))))
+
+    (nskk-it "preserves existing substitution entries on success"
+      (let* ((init '((\?z . 99)))
+             (found nil))
+        (nskk-prolog-unify/k '\?x 42 init
+                             (lambda (s) (setq found s))
+                             #'ignore)
+        (should (equal (nskk-prolog-walk '\?z found) 99))
+        (should (equal (nskk-prolog-walk '\?x found) 42)))))
+
+  (nskk-context "on-not-found path"
+    (nskk-it "calls on-not-found for two different atoms"
+      (let ((not-found nil))
+        (nskk-prolog-unify/k 'a 'b nil
+                             (lambda (_s) nil)
+                             (lambda () (setq not-found t)))
+        (should not-found)))
+
+    (nskk-it "calls on-not-found when lists have different lengths"
+      (let ((not-found nil))
+        (nskk-prolog-unify/k '(a b) '(a b c) nil
+                             (lambda (_s) nil)
+                             (lambda () (setq not-found t)))
+        (should not-found)))
+
+    (nskk-it "calls on-not-found when a nested element fails to unify"
+      (let ((not-found nil))
+        (nskk-prolog-unify/k '(a (b 1)) '(a (b 2)) nil
+                             (lambda (_s) nil)
+                             (lambda () (setq not-found t)))
+        (should not-found)))))
+
+;;;;
 ;;;; 4. Clause Database & Assert/Retract
 ;;;;
 
@@ -1226,7 +1295,62 @@ the database in the same state as before the assertion."
     (nskk-it "returns nil when no trie index is configured for the predicate"
       (nskk-prolog-test-with-isolated-db
         (nskk-prolog-clear-database)
-        (should-not (nskk-prolog-trie-prefix-search 'no-such-pred 2 "x"))))))
+        (should-not (nskk-prolog-trie-prefix-search 'no-such-pred 2 "x")))))
+
+  (nskk-context "nskk-prolog-trie-has-prefix-p"
+    (nskk-it "returns non-nil when prefix is a proper prefix of an indexed key"
+      (nskk-prolog-test-with-isolated-db
+        (nskk-prolog-clear-database)
+        (nskk-prolog-set-index 'has-pfx-word 2 :trie)
+        (nskk-prolog-trie-bulk-assert 'has-pfx-word 2
+                                      '(("hello" . "greeting")
+                                        ("world" . "noun")))
+        (should (nskk-prolog-trie-has-prefix-p 'has-pfx-word 2 "hel"))))
+
+    (nskk-it "returns non-nil for an exact key match (exact is also a valid prefix)"
+      (nskk-prolog-test-with-isolated-db
+        (nskk-prolog-clear-database)
+        (nskk-prolog-set-index 'has-pfx-exact 2 :trie)
+        (nskk-prolog-trie-bulk-assert 'has-pfx-exact 2
+                                      '(("か" . ("花" "家"))))
+        (should (nskk-prolog-trie-has-prefix-p 'has-pfx-exact 2 "か"))))
+
+    (nskk-it "returns nil when prefix matches nothing"
+      (nskk-prolog-test-with-isolated-db
+        (nskk-prolog-clear-database)
+        (nskk-prolog-set-index 'has-pfx-miss 2 :trie)
+        (nskk-prolog-trie-bulk-assert 'has-pfx-miss 2
+                                      '(("alpha" . "a")))
+        (should-not (nskk-prolog-trie-has-prefix-p 'has-pfx-miss 2 "beta"))))
+
+    (nskk-it "returns nil when no trie index is configured for the predicate"
+      (nskk-prolog-test-with-isolated-db
+        (nskk-prolog-clear-database)
+        (should-not (nskk-prolog-trie-has-prefix-p 'no-trie-pred 2 "x"))))
+
+    (nskk-it "works with Japanese kana prefixes"
+      (nskk-prolog-test-with-isolated-db
+        (nskk-prolog-clear-database)
+        (nskk-prolog-set-index 'has-pfx-kana 2 :trie)
+        (nskk-prolog-trie-bulk-assert 'has-pfx-kana 2
+                                      '(("かな" . ("仮名"))
+                                        ("かき" . ("柿" "書記"))
+                                        ("さ" . ("差"))))
+        ;; "か" is a prefix of both "かな" and "かき"
+        (should (nskk-prolog-trie-has-prefix-p 'has-pfx-kana 2 "か"))
+        ;; "さ" is an exact match (also a valid prefix node)
+        (should (nskk-prolog-trie-has-prefix-p 'has-pfx-kana 2 "さ"))
+        ;; "き" matches nothing
+        (should-not (nskk-prolog-trie-has-prefix-p 'has-pfx-kana 2 "き"))))
+
+    (nskk-it "empty prefix returns non-nil when trie has entries (root always exists)"
+      (nskk-prolog-test-with-isolated-db
+        (nskk-prolog-clear-database)
+        (nskk-prolog-set-index 'has-pfx-root 2 :trie)
+        (nskk-prolog-trie-bulk-assert 'has-pfx-root 2
+                                      '(("x" . "val")))
+        ;; Empty string is a prefix of everything; root node always present
+        (should (nskk-prolog-trie-has-prefix-p 'has-pfx-root 2 ""))))))
 
 ;;;;
 ;;;; 16. Built-in Goal Handlers: assertz and retract
@@ -1572,7 +1696,20 @@ the database in the same state as before the assertion."
     (should-error (nskk--prolog-eval-arith '(% 10 3) nil)))
 
   (nskk-it "signals error for a non-number non-compound expression"
-    (should-error (nskk--prolog-eval-arith "not-a-number" nil))))
+    (should-error (nskk--prolog-eval-arith "not-a-number" nil)))
+
+  (nskk-it "evaluates a bound Emacs Lisp symbol (defconst/defvar) as its value"
+    ;; most-positive-fixnum is a globally-bound Emacs built-in constant;
+    ;; it satisfies (symbolp), (not (nskk-prolog-variable-p)), and (boundp).
+    (should (= most-positive-fixnum
+               (nskk--prolog-eval-arith 'most-positive-fixnum nil))))
+
+  (nskk-it "evaluates compound expression with a bound symbol operand"
+    (should (= 0
+               (nskk--prolog-eval-arith '(- most-positive-fixnum most-positive-fixnum) nil))))
+
+  (nskk-it "signals error for unbound Prolog variable in arithmetic"
+    (should-error (nskk--prolog-eval-arith '\?unbound nil))))
 
 ;;;;
 ;;;; 17. set-index Idempotency and retract-all Edge Cases
@@ -1897,7 +2034,7 @@ the database in the same state as before the assertion."
 ;;;;
 
 (nskk-deftest-table prolog-deffacts-call-count
-  :columns (fact-count expansion-args description)
+  :columns (fact-count expansion-args _description)
   :rows    ((0 ()                                       "empty fact list → zero nskk-prolog-<- calls")
             (1 ((a b c))                               "single row → exactly one call")
             (3 ((k1 v1) (k2 v2) (k3 v3))              "three rows → three calls"))

--- a/test/unit/nskk-region-test.el
+++ b/test/unit/nskk-region-test.el
@@ -1,0 +1,217 @@
+;;; nskk-region-test.el --- Tests for nskk-region.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 NSKK Authors
+
+;; Author: takeokunn <bararararatty@gmail.com>
+;; Keywords: japanese, input, test
+
+;; This file is part of NSKK.
+
+;;; Commentary:
+
+;; Tests for nskk-region.el covering:
+;; - Function existence (fboundp)
+;; - ASCII to full-width conversion (nskk--ascii-char-to-zenkaku)
+;; - Full-width to ASCII conversion (nskk--zenkaku-char-to-ascii)
+;; - String-level bidirectional conversion
+;; - Region commands: hiragana-region, katakana-region
+;; - Region commands: hankaku/zenkaku-katakana-region
+;; - Region commands: jisx0208-latin-region, latin-region
+;; - Edge cases: empty string, mixed content, non-convertible chars
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'nskk-region)
+(require 'nskk-test-framework)
+(require 'nskk-test-macros)
+
+;;;; Function Existence
+
+(nskk-describe "nskk-region function existence"
+  (nskk-it "nskk-hiragana-region is defined"
+    (should (fboundp 'nskk-hiragana-region)))
+  (nskk-it "nskk-katakana-region is defined"
+    (should (fboundp 'nskk-katakana-region)))
+  (nskk-it "nskk-hankaku-katakana-region is defined"
+    (should (fboundp 'nskk-hankaku-katakana-region)))
+  (nskk-it "nskk-zenkaku-katakana-region is defined"
+    (should (fboundp 'nskk-zenkaku-katakana-region)))
+  (nskk-it "nskk-jisx0208-latin-region is defined"
+    (should (fboundp 'nskk-jisx0208-latin-region)))
+  (nskk-it "nskk-latin-region is defined"
+    (should (fboundp 'nskk-latin-region))))
+
+;;;; ASCII ↔ Full-Width Single Character Conversion
+
+(nskk-deftest-table ascii-to-zenkaku-chars
+  :columns (char expected)
+  :rows ((?A "Ａ")
+         (?a "ａ")
+         (?z "ｚ")
+         (?Z "Ｚ")
+         (?0 "０")
+         (?9 "９")
+         (?! "！")
+         (?  "\u3000"))
+  :body
+  (should (equal (nskk--ascii-char-to-zenkaku char) expected)))
+
+(nskk-deftest-table zenkaku-to-ascii-chars
+  :columns (char expected)
+  :rows ((?Ａ "A")
+         (?ａ "a")
+         (?ｚ "z")
+         (?Ｚ "Z")
+         (?０ "0")
+         (?９ "9")
+         (?！ "!")
+         (?\u3000 " "))
+  :body
+  (should (equal (nskk--zenkaku-char-to-ascii char) expected)))
+
+(nskk-describe "nskk--ascii-char-to-zenkaku passthrough"
+  (nskk-it "converts tab to tab (non-printable passthrough)"
+    (should (equal (nskk--ascii-char-to-zenkaku ?\t) "\t")))
+  (nskk-it "passes through kanji unchanged"
+    (should (equal (nskk--ascii-char-to-zenkaku ?漢) "漢"))))
+
+(nskk-describe "nskk--zenkaku-char-to-ascii passthrough"
+  (nskk-it "passes through hiragana unchanged"
+    (should (equal (nskk--zenkaku-char-to-ascii ?あ) "あ")))
+  (nskk-it "passes through katakana unchanged"
+    (should (equal (nskk--zenkaku-char-to-ascii ?ア) "ア"))))
+
+;;;; String-Level Conversion
+
+(nskk-describe "nskk--string-ascii-to-zenkaku"
+  (nskk-it "converts ASCII string to full-width"
+    (should (equal (nskk--string-ascii-to-zenkaku "abc") "ａｂｃ")))
+  (nskk-it "converts uppercase ASCII"
+    (should (equal (nskk--string-ascii-to-zenkaku "ABC") "ＡＢＣ")))
+  (nskk-it "converts digits"
+    (should (equal (nskk--string-ascii-to-zenkaku "123") "１２３")))
+  (nskk-it "converts space to ideographic space"
+    (should (equal (nskk--string-ascii-to-zenkaku "a b") "ａ\u3000ｂ")))
+  (nskk-it "passes through non-ASCII chars"
+    (should (equal (nskk--string-ascii-to-zenkaku "あ") "あ")))
+  (nskk-it "handles empty string"
+    (should (equal (nskk--string-ascii-to-zenkaku "") "")))
+  (nskk-it "round-trips with zenkaku-to-ascii"
+    (let ((original "Hello World 123!"))
+      (should (equal (nskk--string-zenkaku-to-ascii
+                      (nskk--string-ascii-to-zenkaku original))
+                     original)))))
+
+(nskk-describe "nskk--string-zenkaku-to-ascii"
+  (nskk-it "converts full-width string to ASCII"
+    (should (equal (nskk--string-zenkaku-to-ascii "ａｂｃ") "abc")))
+  (nskk-it "converts uppercase full-width"
+    (should (equal (nskk--string-zenkaku-to-ascii "ＡＢＣ") "ABC")))
+  (nskk-it "converts ideographic space to ASCII space"
+    (should (equal (nskk--string-zenkaku-to-ascii "\u3000") " ")))
+  (nskk-it "passes through hiragana unchanged"
+    (should (equal (nskk--string-zenkaku-to-ascii "あいう") "あいう")))
+  (nskk-it "handles empty string"
+    (should (equal (nskk--string-zenkaku-to-ascii "") ""))))
+
+;;;; Region Commands (buffer-based)
+
+(nskk-describe "nskk-katakana-region"
+  (nskk-it "converts hiragana region to katakana"
+    (with-temp-buffer
+      (insert "あいう")
+      (nskk-katakana-region (point-min) (point-max))
+      (should (equal (buffer-string) "アイウ"))))
+  (nskk-it "passes through non-hiragana content"
+    (with-temp-buffer
+      (insert "ABC")
+      (nskk-katakana-region (point-min) (point-max))
+      (should (equal (buffer-string) "ABC"))))
+  (nskk-it "handles empty region"
+    (with-temp-buffer
+      (nskk-katakana-region (point-min) (point-max))
+      (should (equal (buffer-string) "")))))
+
+(nskk-describe "nskk-hiragana-region"
+  (nskk-it "converts katakana region to hiragana"
+    (with-temp-buffer
+      (insert "アイウ")
+      (nskk-hiragana-region (point-min) (point-max))
+      (should (equal (buffer-string) "あいう"))))
+  (nskk-it "passes through non-katakana content"
+    (with-temp-buffer
+      (insert "abc")
+      (nskk-hiragana-region (point-min) (point-max))
+      (should (equal (buffer-string) "abc"))))
+  (nskk-it "is inverse of katakana-region"
+    (with-temp-buffer
+      (insert "さしすせそ")
+      (let ((original (buffer-string)))
+        (nskk-katakana-region (point-min) (point-max))
+        (nskk-hiragana-region (point-min) (point-max))
+        (should (equal (buffer-string) original))))))
+
+(nskk-describe "nskk-jisx0208-latin-region"
+  (nskk-it "converts ASCII region to full-width"
+    (with-temp-buffer
+      (insert "abc")
+      (nskk-jisx0208-latin-region (point-min) (point-max))
+      (should (equal (buffer-string) "ａｂｃ"))))
+  (nskk-it "handles mixed ASCII and non-ASCII"
+    (with-temp-buffer
+      (insert "aあb")
+      (nskk-jisx0208-latin-region (point-min) (point-max))
+      (should (equal (buffer-string) "ａあｂ")))))
+
+(nskk-describe "nskk-latin-region"
+  (nskk-it "converts full-width region to ASCII"
+    (with-temp-buffer
+      (insert "ａｂｃ")
+      (nskk-latin-region (point-min) (point-max))
+      (should (equal (buffer-string) "abc"))))
+  (nskk-it "is inverse of jisx0208-latin-region for pure ASCII"
+    (with-temp-buffer
+      (insert "Hello123")
+      (let ((original (buffer-string)))
+        (nskk-jisx0208-latin-region (point-min) (point-max))
+        (nskk-latin-region (point-min) (point-max))
+        (should (equal (buffer-string) original))))))
+
+(nskk-describe "nskk-hankaku-katakana-region"
+  (nskk-it "converts zenkaku katakana to hankaku"
+    (with-temp-buffer
+      (insert "アイウ")
+      (nskk-hankaku-katakana-region (point-min) (point-max))
+      ;; ア→ｱ(U+FF71), イ→ｲ(U+FF72), ウ→ｳ(U+FF73)
+      (should (equal (buffer-string) "\uff71\uff72\uff73"))))
+  (nskk-it "converts a full row of zenkaku katakana to hankaku"
+    (with-temp-buffer
+      (insert "アイウエオ")
+      (nskk-hankaku-katakana-region (point-min) (point-max))
+      (should (equal (buffer-string) "\uff71\uff72\uff73\uff74\uff75"))))
+  (nskk-it "passes through non-katakana unchanged"
+    (with-temp-buffer
+      (insert "abc")
+      (nskk-hankaku-katakana-region (point-min) (point-max))
+      (should (equal (buffer-string) "abc")))))
+
+(nskk-describe "nskk-zenkaku-katakana-region"
+  (nskk-it "converts hankaku katakana to zenkaku"
+    (with-temp-buffer
+      ;; Half-width katakana: ｱｲｳ
+      (insert "\uff71\uff72\uff73")
+      (nskk-zenkaku-katakana-region (point-min) (point-max))
+      (should (equal (buffer-string) "アイウ"))))
+  (nskk-it "is inverse of hankaku-katakana-region"
+    (with-temp-buffer
+      (insert "アイウエオ")
+      (let ((original (buffer-string)))
+        (nskk-hankaku-katakana-region (point-min) (point-max))
+        (nskk-zenkaku-katakana-region (point-min) (point-max))
+        (should (equal (buffer-string) original))))))
+
+(provide 'nskk-region-test)
+
+;;; nskk-region-test.el ends here

--- a/test/unit/nskk-search-test.el
+++ b/test/unit/nskk-search-test.el
@@ -39,7 +39,8 @@
   "Create a test dict-index backed by Prolog facts.
 ENTRIES-ALIST is ((key . candidates-list) ...) for exact-match entries.
 TRIE-ENTRIES is ((key . candidates-list) ...) for trie-indexed entries.
-PRED-NAME is the Prolog predicate symbol (defaults to a unique generated symbol)."
+PRED-NAME is the Prolog predicate symbol (defaults to a unique
+generated symbol)."
   (let* ((pred (or pred-name (intern (format "test-dict-%d" (abs (random))))))
          (all-entries (append entries-alist trie-entries)))
     (nskk-prolog-set-index pred 2 :trie)
@@ -163,7 +164,7 @@ PRED-NAME is the Prolog predicate symbol (defaults to a unique generated symbol)
                       '(("abc" . ("v1")) ("xyz" . ("v2"))))))
           (let ((results (nskk-search index "abc" 'fuzzy)))
             (should (listp results))
-            (should (> (length results) 0))
+            (should results)
             ;; The exact match should be first (distance 0)
             (let ((first-result (car results)))
               (should (equal (car first-result) "abc")))))))
@@ -234,7 +235,7 @@ PRED-NAME is the Prolog predicate symbol (defaults to a unique generated symbol)
 
 ;; Table-driven: covers all canonical edit-distance cases in one declaration
 (nskk-deftest-table levenshtein-known-distances
-  :columns (s1 s2 expected label)
+  :columns (s1 s2 expected _label)
   :rows (("abc"    "abc"      0  "identical strings")
          (""       ""         0  "both empty")
          ("abc"    ""         3  "deletion to empty")
@@ -299,7 +300,7 @@ PRED-NAME is the Prolog predicate symbol (defaults to a unique generated symbol)
 
 ;; Table-driven: all combinations of okuri-type × entry-okuri
 (nskk-deftest-table match-okuri-type-p-cases
-  :columns (okuri-type entry-okuri matches-p label)
+  :columns (okuri-type entry-okuri matches-p _label)
   :rows ((okuri-ari  "し"  t   "ari: non-empty okuri matches")
          (okuri-ari  nil   nil "ari: nil okuri does not match")
          (okuri-nasi nil   t   "nasi: nil okuri matches")
@@ -488,7 +489,7 @@ in this list.")
 
   ;; PBT-004 -- Cache key uniqueness (table-driven)
   (nskk-deftest-table search-cache-key-uniqueness
-    :columns (query type okuri label)
+    :columns (query type okuri _label)
     :rows (("query1" exact   nil         "exact-no-okuri")
            ("query1" prefix  nil         "prefix-no-okuri")
            ("query1" exact   okuri-ari   "exact-okuri-ari")
@@ -784,7 +785,7 @@ in this list.")
         ;; Fuzzy search
         (let ((nskk-search-fuzzy-threshold 2)
               (results (nskk-search index "かんじ" 'fuzzy)))
-          (should (> (length results) 0))))))
+          (should results)))))
 
 )
 
@@ -874,7 +875,7 @@ in this list.")
 (nskk-property-test search-cache-key-always-string
   ((q search-query))
   (let ((key (nskk--search-cache-key q 'exact nil)))
-    (and (stringp key) (> (length key) 0)))
+    (and (stringp key) (not (string-empty-p key))))
   30)
 
 ;; PBT-010 — cache key contains the query string

--- a/test/unit/nskk-show-mode-test.el
+++ b/test/unit/nskk-show-mode-test.el
@@ -1,0 +1,317 @@
+;;; nskk-show-mode-test.el --- Tests for nskk-show-mode.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 NSKK Authors
+
+;; Author: takeokunn <bararararatty@gmail.com>
+;; Keywords: japanese, input, test
+
+;; This file is part of NSKK.
+
+;;; Commentary:
+
+;; Tests for nskk-show-mode.el covering:
+;; - Function existence (fboundp)
+;; - Customization variables
+;; - nskk--show-mode-indicator-string for each mode
+;; - nskk--show-mode-hide cleanup behavior
+;; - nskk-show-mode-display guard conditions
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'nskk-show-mode)
+(require 'nskk-state)
+(require 'nskk-prolog)
+(require 'nskk-test-framework)
+(require 'nskk-test-macros)
+
+;;;; Function Existence
+
+(nskk-describe "nskk-show-mode function existence"
+  (nskk-it "nskk-show-mode-display is defined"
+    (should (fboundp 'nskk-show-mode-display)))
+  (nskk-it "nskk--show-mode-indicator-string is defined"
+    (should (fboundp 'nskk--show-mode-indicator-string)))
+  (nskk-it "nskk--show-mode-hide is defined"
+    (should (fboundp 'nskk--show-mode-hide))))
+
+;;;; Customization
+
+(nskk-describe "nskk-show-mode customization variables"
+  (nskk-it "nskk-show-mode-show is defined as a boolean defcustom"
+    (should (boundp 'nskk-show-mode-show)))
+  (nskk-it "nskk-show-mode-style is defined"
+    (should (boundp 'nskk-show-mode-style)))
+  (nskk-it "nskk-show-mode-duration is a number"
+    (should (numberp nskk-show-mode-duration)))
+  (nskk-it "nskk-show-mode-style is one of valid choices"
+    (should (memq nskk-show-mode-style '(inline tooltip)))))
+
+;;;; Indicator String
+
+(nskk-describe "nskk--show-mode-indicator-string"
+  (nskk-it "returns nil for unknown mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (should (null (nskk--show-mode-indicator-string 'nonexistent-mode)))))
+
+  (nskk-it "returns a string for hiragana mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'hiragana)))
+        (should (stringp result)))))
+
+  (nskk-it "returns a string for katakana mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'katakana)))
+        (should (stringp result)))))
+
+  (nskk-it "result is bracket-wrapped"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'hiragana)))
+        (when result
+          (should (string-prefix-p "[" result))
+          (should (string-suffix-p "]" result))))))
+
+  (nskk-it "returns a string for ascii mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'ascii)))
+        (should (stringp result)))))
+
+  (nskk-it "returns a string for jisx0208-latin mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'jisx0208-latin)))
+        (should (stringp result)))))
+
+  (nskk-it "returns a string for abbrev mode"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'abbrev)))
+        (should (stringp result)))))
+
+  (nskk-it "result has face property applied"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (let ((result (nskk--show-mode-indicator-string 'hiragana)))
+        (when result
+          (should (eq (get-text-property 0 'face result)
+                      'nskk-show-mode-inline-face)))))))
+
+;;;; Display Guards
+
+(nskk-describe "nskk-show-mode-display no-op conditions"
+  (nskk-it "is a no-op when nskk-show-mode-show is nil"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'hiragana))
+        (let ((nskk-show-mode-show nil))
+          ;; Should not error
+          (should-not (condition-case err
+                          (progn (nskk-show-mode-display) nil)
+                        (error err)))))))
+
+  (nskk-it "is a no-op when nskk-current-state is nil"
+    (nskk-prolog-test-with-isolated-db
+      (with-temp-buffer
+        (setq nskk-current-state nil)
+        (let ((nskk-show-mode-show t))
+          (should-not (condition-case err
+                          (progn (nskk-show-mode-display) nil)
+                        (error err))))))))
+
+;;;; Hide Cleanup
+
+(nskk-describe "nskk--show-mode-hide"
+  (nskk-it "is safe to call when overlay is nil"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk--show-mode-last-mode nil))
+        ;; Should not signal an error
+        (should-not (condition-case err
+                        (progn (nskk--show-mode-hide) nil)
+                      (error err))))))
+
+  (nskk-it "clears last-mode after hide"
+    (with-temp-buffer
+      (setq nskk--show-mode-last-mode 'hiragana)
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil))
+        (nskk--show-mode-hide)
+        (should (null nskk--show-mode-last-mode))))))
+
+;;;; Exact Indicator String Content
+
+(nskk-deftest-table show-mode-indicator-exact-strings
+  :columns (mode expected-content)
+  :rows ((hiragana       "かな")
+         (katakana       "カナ")
+         (ascii          "SKK")
+         (jisx0208-latin "全英")
+         (abbrev         "aA"))
+  :description "nskk--show-mode-indicator-string returns exact [DISPLAY] bracket string"
+  :body
+  (nskk-prolog-test-with-isolated-db
+    (nskk-state-initialize-prolog)
+    (should (equal (nskk--show-mode-indicator-string mode)
+                   (propertize (format "[%s]" expected-content)
+                               'face 'nskk-show-mode-inline-face)))))
+
+;;;; nskk--show-mode-display-inline
+
+(nskk-describe "nskk--show-mode-display-inline"
+  (nskk-it "creates an overlay in the current buffer"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk-show-mode-duration 60))
+        (nskk--show-mode-display-inline "[か]")
+        (unwind-protect
+            (should (overlayp nskk--show-mode-overlay))
+          (when (timerp nskk--show-mode-timer)
+            (cancel-timer nskk--show-mode-timer))))))
+
+  (nskk-it "sets after-string property to the indicator string"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk-show-mode-duration 60))
+        (nskk--show-mode-display-inline "[か]")
+        (unwind-protect
+            (should (equal (overlay-get nskk--show-mode-overlay 'after-string)
+                           "[か]"))
+          (when (timerp nskk--show-mode-timer)
+            (cancel-timer nskk--show-mode-timer))))))
+
+  (nskk-it "schedules a timer for auto-hide"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk-show-mode-duration 60))
+        (nskk--show-mode-display-inline "[か]")
+        (unwind-protect
+            (should (timerp nskk--show-mode-timer))
+          (when (timerp nskk--show-mode-timer)
+            (cancel-timer nskk--show-mode-timer))))))
+
+  (nskk-it "cancels and replaces previous timer on second call"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk-show-mode-duration 60)
+            first-timer)
+        (nskk--show-mode-display-inline "[か]")
+        (setq first-timer nskk--show-mode-timer)
+        (nskk--show-mode-display-inline "[ア]")
+        (unwind-protect
+            (should (not (eq first-timer nskk--show-mode-timer)))
+          (when (timerp nskk--show-mode-timer)
+            (cancel-timer nskk--show-mode-timer))))))
+
+  (nskk-it "overlay priority is 100"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk-show-mode-duration 60))
+        (nskk--show-mode-display-inline "[か]")
+        (unwind-protect
+            (should (= (overlay-get nskk--show-mode-overlay 'priority) 100))
+          (when (timerp nskk--show-mode-timer)
+            (cancel-timer nskk--show-mode-timer)))))))
+
+;;;; nskk--show-mode-hide cancels timer
+
+(nskk-describe "nskk--show-mode-hide timer handling"
+  (nskk-it "cancels pending timer when one exists"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk--show-mode-last-mode nil)
+            (nskk-show-mode-duration 60))
+        (nskk--show-mode-display-inline "[か]")
+        ;; Timer was created
+        (should (timerp nskk--show-mode-timer))
+        (nskk--show-mode-hide)
+        ;; Timer was cancelled and cleared
+        (should (null nskk--show-mode-timer)))))
+
+  (nskk-it "removes the overlay when one exists"
+    (with-temp-buffer
+      (let ((nskk--show-mode-overlay nil)
+            (nskk--show-mode-timer nil)
+            (nskk--show-mode-last-mode nil)
+            (nskk-show-mode-duration 60))
+        (nskk--show-mode-display-inline "[か]")
+        (should (overlayp nskk--show-mode-overlay))
+        (nskk--show-mode-hide)
+        (should (null nskk--show-mode-overlay))))))
+
+;;;; nskk-show-mode-display integration
+
+(nskk-describe "nskk-show-mode-display integration"
+  (nskk-it "updates nskk--show-mode-last-mode after first display"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'hiragana))
+        (let ((nskk-show-mode-show t)
+              (nskk-show-mode-style 'inline)
+              (nskk-show-mode-duration 60)
+              (nskk--show-mode-overlay nil)
+              (nskk--show-mode-timer nil)
+              (nskk--show-mode-last-mode nil))
+          (nskk-show-mode-display)
+          (unwind-protect
+              (should (eq nskk--show-mode-last-mode 'hiragana))
+            (when (timerp nskk--show-mode-timer)
+              (cancel-timer nskk--show-mode-timer)))))))
+
+  (nskk-it "skips display when mode is unchanged (deduplication)"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'hiragana))
+        (let ((nskk-show-mode-show t)
+              (nskk-show-mode-style 'inline)
+              (nskk-show-mode-duration 60)
+              (nskk--show-mode-overlay nil)
+              (nskk--show-mode-timer nil)
+              (nskk--show-mode-last-mode 'hiragana)  ; pre-set: same as current
+              (call-count 0))
+          (cl-letf (((symbol-function 'nskk--show-mode-display-inline)
+                     (lambda (_s) (cl-incf call-count))))
+            (nskk-show-mode-display)
+            (should (= call-count 0)))))))
+
+  (nskk-it "re-displays when mode changes"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-state-initialize-prolog)
+      (with-temp-buffer
+        (setq nskk-current-state (nskk-state-create 'katakana))
+        (let ((nskk-show-mode-show t)
+              (nskk-show-mode-style 'inline)
+              (nskk-show-mode-duration 60)
+              (nskk--show-mode-overlay nil)
+              (nskk--show-mode-timer nil)
+              (nskk--show-mode-last-mode 'hiragana)  ; different from current
+              (call-count 0))
+          (cl-letf (((symbol-function 'nskk--show-mode-display-inline)
+                     (lambda (_s) (cl-incf call-count))))
+            (nskk-show-mode-display)
+            (should (= call-count 1))))))))
+
+;;;; Face Definitions
+
+(nskk-describe "nskk-show-mode-inline-face"
+  (nskk-it "is defined as a face"
+    (should (facep 'nskk-show-mode-inline-face))))
+
+(provide 'nskk-show-mode-test)
+
+;;; nskk-show-mode-test.el ends here

--- a/test/unit/nskk-state-test.el
+++ b/test/unit/nskk-state-test.el
@@ -1126,7 +1126,7 @@ Delegates to `nskk--simulate-key-for-state' from nskk-test-macros."
   ;; The romaji-string generator always produces non-empty strings.
   (let ((state (nskk-state-create)))
     (let ((before-len (length (nskk-state-input-buffer state))))
-      (if (> (length input) 0)
+      (if (not (string-empty-p input))
           (progn
             (nskk-state-append-input state (aref input 0))
             (let ((after-len (length (nskk-state-input-buffer state))))
@@ -1219,7 +1219,7 @@ Delegates to `nskk--simulate-key-for-state' from nskk-test-macros."
 (nskk-property-test state-pbt-append-cps-consistent-with-sync
   ((input romaji-string))
   ;; append-input/k must produce the same result as the sync variant.
-  (when (> (length input) 0)
+  (when (not (string-empty-p input))
     (let* ((char (aref input 0))
            (state1 (nskk-state-create))
            (state2 (nskk-state-create))
@@ -1431,6 +1431,7 @@ Delegates to `nskk--simulate-key-for-state' from nskk-test-macros."
           executed)
       (nskk-state-set-candidates state '("漢字" "感じ"))
       (nskk-with-candidates state
+        (ignore candidates index)
         (setq executed t))
       (should executed)))
 
@@ -1451,12 +1452,14 @@ Delegates to `nskk--simulate-key-for-state' from nskk-test-macros."
           executed)
       ;; No candidates set -> nskk-state-candidates returns nil
       (nskk-with-candidates state
+        (ignore candidates index)
         (setq executed t))
       (should-not executed)))
 
   (nskk-it "does not execute body when state is not an nskk-state struct"
     (let (executed)
       (nskk-with-candidates nil
+        (ignore candidates index)
         (setq executed t))
       (should-not executed))))
 


### PR DESCRIPTION
## Summary

- **Idiomatic Emacs Lisp refactoring**: pcase pattern matching across all modules, let*/let cleanup, `(unless)` for `(when (not))`, positive-first guard style, De Morgan simplifications, `string-empty-p`/`string-match-p` consistency
- **Build hygiene**: zero byte-compile warnings in all source and test files, explicit `(require 'cl-lib)` and `(require 'subr-x)` where needed, `:package-version` completeness for all `defcustom`/`defface` entries
- **Bug fixes**: ja-dic candidate order (removed spurious `reverse`), DA/DV AZIK state not cleared by `cancel-preedit`/`rollback`
- **+102 new unit tests**: numeric conversion (53), prolog trie/phase (22), show-mode (15), annotation, context, inline, isearch, region; total **5316 passing** (unit:3944 + integration:523 + e2e:849, 0 failures)

## Test plan

- [x] All 5316 tests pass (unit + integration + e2e)
- [x] Zero byte-compile warnings
- [ ] Manual smoke test of basic SKK input flow