### PR TITLE
feat: add undo-kakutei, dict-unregister, and purge-from-jisyo

### DIFF
--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ No external ELPA packages required.
 | Lexical binding  | All 25 modules use =lexical-binding: t= |
 | Prolog engine    | Conversion rules as facts/queries       |
 | Layer separation | 7 strict layers, zero circular deps     |
-| Test coverage    | 5,000+ unit/integration/E2E tests       |
+| Test coverage    | 5,454+ unit/integration/E2E tests       |
 
 ** DDSKK Compatibility
 
@@ -164,11 +164,13 @@ stateDiagram-v2
 |---------+----------------------+-----------------------------------|
 | =SPC=   | =nskk-handle-space=  | Start conversion / next candidate |
 | =x=     | =nskk-handle-x=      | Previous candidate                |
+| =X=     | =nskk-handle-upper-x=  | Purge candidate from user dictionary |
 | =RET=   | =nskk-handle-return= | Commit candidate + newline        |
 | =C-g=   | =nskk-handle-cancel= | Cancel conversion or preedit      |
 | =a=–=l= | direct select        | Select candidate in list mode     |
 | =C-n=   | =nskk-handle-ctrl-n= | Next candidate OR next line       |
 | =C-p=   | =nskk-handle-ctrl-p= | Prev candidate OR previous line   |
+| =C-/=   | =nskk-undo-kakutei=    | Undo last kakutei (revert commit)    |
 
 *** Cursor Movement (in Conversion Mode)
 

--- a/nskk-dictionary.el
+++ b/nskk-dictionary.el
@@ -163,6 +163,24 @@ Only used when `nskk-dict-system-dictionary-files' is nil."
   (not (user-dict-entry \?reading \?_))
   (assertz (user-dict-entry \?reading (\?word))))
 
+;; Dictionary unregistration rule using retract/assertz builtins
+;; Clause 1: word is the sole candidate, retract entire entry
+(nskk-prolog-<- (dict-unregister \?reading \?word)
+  (user-dict-entry \?reading (\?word))
+  (retract (user-dict-entry \?reading (\?word))))
+;; Clause 2: remove word from multi-candidate entry (keep remaining)
+(nskk-prolog-<- (dict-unregister \?reading \?word)
+  (user-dict-entry \?reading \?existing)
+  (member \?word \?existing)
+  (retract (user-dict-entry \?reading \?existing))
+  (remove-element \?word \?existing \?rest)
+  (assertz (user-dict-entry \?reading \?rest)))
+
+;; List element removal helper (needed for dict-unregister rule)
+(nskk-prolog-<- (remove-element \?x (\?x . \?rest) \?rest))
+(nskk-prolog-<- (remove-element \?x (\?y . \?tail) (\?y . \?result))
+  (remove-element \?x \?tail \?result))
+
 ;;; Section 3: Data structures
 
 (cl-defstruct nskk-dict-entry
@@ -662,6 +680,29 @@ are empty/invalid or when the Prolog registration query fails."
   (if (and (stringp reading) (not (string-empty-p reading))
            (stringp word)   (not (string-empty-p word))
            (nskk--dict-register-impl reading word))
+      (succeed t)
+    (fail)))
+
+(defun nskk--dict-unregister-impl (reading word)
+  "Attempt to unregister WORD for READING from the Prolog user dictionary.
+Returns t on success (Prolog dict-unregister/2 succeeded), nil on failure."
+  (when (and nskk--user-dict-index
+             (nskk-prolog-holds-p `(dict-unregister ,reading ,word)))
+    (setq nskk-dict-modified t)
+    (nskk--dict-run-update-hook)
+    (message "NSKK: Unregistered %s -> %s" reading word)
+    t))
+
+;;;###autoload
+(defun/k nskk-dict-unregister-word (reading word)
+  "Unregister WORD as a conversion candidate for READING from user dictionary.
+Uses the Prolog dict-unregister rule which removes the word from an
+existing entry (or retracts the entire entry if it was the sole candidate).
+Returns non-nil (t) on success; calls on-not-found when READING or WORD
+are empty/invalid or when the Prolog unregistration query fails."
+  (if (and (stringp reading) (not (string-empty-p reading))
+           (stringp word)   (not (string-empty-p word))
+           (nskk--dict-unregister-impl reading word))
       (succeed t)
     (fail)))
 

--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -112,6 +112,8 @@
 (declare-function nskk-state-previous-mode "nskk-state")
 (declare-function nskk-dict-register-word "nskk-dictionary")
 (declare-function nskk-dict-register-word/k "nskk-dictionary")
+(declare-function nskk-dict-unregister-word "nskk-dictionary")
+(declare-function nskk-dict-unregister-word/k "nskk-dictionary")
 (declare-function nskk-dict-lookup "nskk-dictionary")
 (declare-function nskk-dict-lookup/k "nskk-dictionary")
 (declare-function nskk-search-prefix/k "nskk-search")
@@ -153,6 +155,18 @@
 
 (defvar-local nskk--dcomp-index 0
   "Current cycling index into `nskk--dcomp-candidates'.")
+
+;;;; Undo-Kakutei State
+
+(defvar-local nskk--last-kakutei-record nil
+  "Undo record for the most recent kakutei, or nil.
+A plist with keys: :reading, :candidates, :index,
+:committed-text, :buffer-start, :buffer-end, :mode,
+:registered-p, :registered-reading, :registered-word.
+Set by `nskk-commit-current' and
+`nskk--insert-registered-and-reset'.
+Invalidated by `nskk--post-command-handler' when any
+subsequent non-undo command is executed.")
 
 ;;;; Conversion State Macros
 
@@ -667,6 +681,119 @@ Used by `nskk-handle-q' / `nskk-toggle-japanese-mode' in ▽ preedit."
   (nskk-with-current-state
     (nskk-state-set-henkan-phase nskk-current-state nil)))
 
+;;;; Undo-Kakutei
+
+;;;###autoload
+(defun nskk-undo-kakutei ()
+  "Undo the most recent kakutei (確定) operation.
+Reverts the committed text in the buffer, restores ▼ mode with
+the original candidates, and if the kakutei involved a dictionary
+registration, unregisters the word from the user dictionary.
+Only valid immediately after a kakutei; any intervening input
+invalidates the undo record.  When no undo record exists, falls
+through to `undo'."
+  (interactive)
+  (let ((record nskk--last-kakutei-record))
+    (if (null record)
+        (undo)
+      (let ((reading        (plist-get record :reading))
+            (candidates     (plist-get record :candidates))
+            (index          (plist-get record :index))
+            (committed-text (plist-get record :committed-text))
+            (buf-start      (plist-get record :buffer-start))
+            (buf-end        (plist-get record :buffer-end))
+            (registered-p   (plist-get record :registered-p))
+            (reg-reading    (plist-get record :registered-reading))
+            (reg-word       (plist-get record :registered-word)))
+        ;; Invalidate immediately to prevent double-undo.
+        (setq nskk--last-kakutei-record nil)
+        ;; Verify buffer text matches the committed text.
+        (if (and buf-start buf-end (<= buf-end (point-max))
+                 (string= committed-text
+                          (buffer-substring-no-properties
+                           buf-start buf-end)))
+            (progn
+              ;; Unregister from user dict if registration kakutei.
+              (when (and registered-p reg-reading reg-word)
+                (nskk-dict-unregister-word reg-reading reg-word))
+              ;; Replace committed text with ▼ + candidate.
+              (delete-region buf-start buf-end)
+              (goto-char buf-start)
+              (insert nskk-henkan-active-marker)
+              (let ((candidate (nth index candidates)))
+                (when candidate
+                  (insert (substring-no-properties candidate))))
+              ;; Set up conversion overlay.
+              (let ((ov-start (+ buf-start
+                                 (length nskk-henkan-active-marker)))
+                    (ov-end   (point)))
+                (nskk--set-conversion-start-marker buf-start)
+                (nskk--update-overlay
+                 ov-start ov-end (nth index candidates)))
+              ;; Restore conversion state.
+              ;; Use force-henkan-phase: nil → active is not in the
+              ;; normal transition graph, but is safe for undo restore.
+              (nskk-with-current-state
+                (nskk-state-set-candidates
+                 nskk-current-state candidates)
+                (setf (nskk-state-current-index
+                       nskk-current-state) index)
+                (nskk-state-force-henkan-phase
+                 nskk-current-state 'active)
+                (nskk-state-put-metadata
+                 nskk-current-state
+                 'henkan-reading reading)))
+          (message "NSKK: Cannot undo kakutei -- buffer has changed"))))))
+
+(defun nskk--invalidate-undo-kakutei ()
+  "Clear `nskk--last-kakutei-record' to invalidate undo.
+Called from `nskk--post-command-handler' when any non-undo
+command runs."
+  (when nskk--last-kakutei-record
+    (setq nskk--last-kakutei-record nil)))
+
+;;;; Purge from Dictionary
+
+;;;###autoload
+(defun nskk-purge-from-jisyo ()
+  "Purge the current candidate from the user dictionary.
+Only valid during ▼ (active conversion) mode.  Prompts for
+confirmation before removing the candidate.  After purging,
+if candidates remain, shows the next one; otherwise rolls
+back to ▽ (preedit) mode."
+  (interactive)
+  (when (and (nskk-converting-p)
+             (boundp 'nskk-current-state)
+             (nskk-state-p nskk-current-state))
+    (let* ((candidates (nskk-state-candidates nskk-current-state))
+           (index      (nskk-state-current-index nskk-current-state))
+           (candidate  (nth index candidates))
+           (reading    (nskk-state-get-metadata
+                        nskk-current-state 'henkan-reading)))
+      (when (and candidate reading
+                 (yes-or-no-p
+                  (format "Really purge \"%s\" (%s)? "
+                          candidate reading)))
+        (nskk-dict-unregister-word reading candidate)
+        (let ((remaining (cl-remove candidate candidates
+                                    :test #'equal :count 1)))
+          (if remaining
+              ;; Show next candidate from remaining list.
+              (let ((new-idx (min index
+                                  (1- (length remaining)))))
+                (nskk-state-set-candidates
+                 nskk-current-state remaining)
+                (setf (nskk-state-current-index
+                       nskk-current-state) new-idx)
+                (let ((new-cand (nth new-idx remaining)))
+                  (nskk--update-overlay
+                   (+ (nskk--get-conversion-start)
+                      (length nskk-henkan-active-marker))
+                   (overlay-end nskk--conversion-overlay)
+                   new-cand)))
+            ;; No candidates left: rollback to preedit.
+            (nskk-cancel-conversion-to-reading)))))))
+
 ;;;; Conversion Control
 
 ;;;###autoload
@@ -927,16 +1054,34 @@ in place and will immediately follow the inserted candidate."
       ;; Delete overlay before buffer modification to avoid stale display.
       (nskk-delete-overlay nskk--conversion-overlay)
       (when (and start candidate)
-        ;; Delete from start to end: covers reading kana under the overlay
-        ;; AND any okurigana kana between overlay-end and point.
-        ;; Re-insert okuri-kana explicitly so point ends after it.
-        (delete-region start end)
-        (goto-char start)
-        ;; Strip text properties (e.g. nskk-no-learn from built-in program dict
-        ;; handlers) before inserting into the buffer.
-        (insert (substring-no-properties candidate))
-        (when okuri-kana
-          (insert okuri-kana)))
+        ;; Capture undo record BEFORE modifying the buffer.
+        (let ((reading (nskk-state-get-metadata nskk-current-state 'henkan-reading))
+              (mode    (nskk-state-mode nskk-current-state))
+              (committed (substring-no-properties candidate))
+              (committed-with-okuri
+               (concat (substring-no-properties candidate) (or okuri-kana ""))))
+          ;; Delete from start to end: covers reading kana under the overlay
+          ;; AND any okurigana kana between overlay-end and point.
+          ;; Re-insert okuri-kana explicitly so point ends after it.
+          (delete-region start end)
+          (goto-char start)
+          ;; Strip text properties (e.g. nskk-no-learn from built-in program dict
+          ;; handlers) before inserting into the buffer.
+          (insert committed)
+          (when okuri-kana
+            (insert okuri-kana))
+          ;; Store undo record for nskk-undo-kakutei.
+          (setq nskk--last-kakutei-record
+                (list :reading reading
+                      :candidates candidates
+                      :index index
+                      :committed-text committed-with-okuri
+                      :buffer-start start
+                      :buffer-end (point)
+                      :mode mode
+                      :registered-p nil
+                      :registered-reading nil
+                      :registered-word nil))))
       ;; Clear all conversion state (includes candidate list dismissal).
       (nskk-henkan-do-reset)
       (succeed candidate))))
@@ -1170,7 +1315,8 @@ QUERY is the dict lookup key stored in okurigana-query metadata."
   (nskk-with-current-state
     (nskk-set-active-candidates candidates)
     (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress t)
-    (nskk-state-put-metadata nskk-current-state 'okurigana-query query))
+    (nskk-state-put-metadata nskk-current-state 'okurigana-query query)
+    (nskk-state-put-metadata nskk-current-state 'henkan-reading query))
   (setq nskk--henkan-count 1))
 
 (defun nskk--build-okuri-registration-reading (text-start preedit-end query)
@@ -1212,7 +1358,7 @@ candidates are found."
               (nskk-start-registration/k reading
                 (lambda (registered)
                   (if registered
-                      (nskk--insert-registered-and-reset registered start on-register)
+                      (nskk--insert-registered-and-reset registered start on-register reading)
                     (funcall on-not-found)))
                 #'ignore)))))
       on-not-found)))
@@ -1246,7 +1392,8 @@ overlay, sets `nskk--henkan-count' to 1, and stores candidates in state."
     (nskk--replace-marker-at start nskk-henkan-on-marker-regexp nskk-henkan-active-marker)
     (nskk--update-overlay (+ start (length nskk-henkan-active-marker)) end (car candidates))
     (nskk-with-current-state
-      (nskk-set-active-candidates candidates))
+      (nskk-set-active-candidates candidates)
+      (nskk-state-put-metadata nskk-current-state 'henkan-reading lookup-text))
     (funcall on-found candidates)))
 
 (defun nskk--start-conv-register (text start _end on-not-found on-register)
@@ -1259,16 +1406,33 @@ ON-REGISTER is called (no args) after a word is successfully registered."
   (nskk-start-registration/k text
     (lambda (registered)
       (if registered
-          (nskk--insert-registered-and-reset registered start on-register)
+          (nskk--insert-registered-and-reset registered start on-register text)
         (funcall on-not-found)))
     #'ignore))
 
-(defun nskk--insert-registered-and-reset (registered start on-done)
+(defun nskk--insert-registered-and-reset (registered start on-done &optional reading)
   "Insert REGISTERED word at START, reset henkan state, and call ON-DONE.
-Shared by all registration callbacks in the conversion pipeline."
+Shared by all registration callbacks in the conversion pipeline.
+Optional READING is the original reading used for registration; when
+non-nil, an undo record is stored so `nskk-undo-kakutei' can revert
+and unregister the word."
   (delete-region start (point))
   (goto-char start)
   (insert registered)
+  ;; Store undo record for registration undo.
+  (when reading
+    (let ((mode (nskk-with-current-state (nskk-state-mode nskk-current-state))))
+      (setq nskk--last-kakutei-record
+            (list :reading reading
+                  :candidates (list registered)
+                  :index 0
+                  :committed-text registered
+                  :buffer-start start
+                  :buffer-end (point)
+                  :mode (or mode 'hiragana)
+                  :registered-p t
+                  :registered-reading reading
+                  :registered-word registered))))
   (nskk-henkan-do-reset)
   (when (functionp on-done) (funcall on-done)))
 
@@ -1442,7 +1606,7 @@ If the user cancels, wrap around to the first candidate in list display."
               (if registered
                   (progn
                     (nskk-delete-overlay nskk--conversion-overlay)
-                    (nskk--insert-registered-and-reset registered start (lambda ())))
+                    (nskk--insert-registered-and-reset registered start (lambda ()) reading))
                 ;; Registration cancelled: wrap back to first candidate page.
                 (nskk--wrap-to-first-candidate)))
             #'ignore))

--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -78,6 +78,7 @@
 ;; Manually defined handler (AZIK-aware Prolog dispatch):
 ;; - `nskk-handle-l'       -- candidate selection, romaji rule, or ASCII mode switch
 ;;                            (via nskk--handle-l-action / l-key-action/3 dispatch)
+;; - `nskk-handle-upper-x' -- purge candidate from dictionary (X key)
 ;;
 ;; Prolog-dispatched handlers (via `nskk-define-key-handler'):
 ;; - `nskk-handle-x'       -- previous candidate
@@ -129,6 +130,7 @@
 (declare-function nskk-henkan-kakutei "nskk-henkan")
 (declare-function nskk-henkan-kakutei-convert-script "nskk-henkan")
 (declare-function nskk-dynamic-complete "nskk-henkan")
+(declare-function nskk-purge-from-jisyo "nskk-henkan")
 (defvar nskk-henkan-on-marker)
 
 ;;;; Prolog Key-Action Rules
@@ -607,6 +609,16 @@ In ASCII mode or when NSKK state is inactive, fall through to
     (nskk--with-japanese-mode/k
      (lambda (_) (nskk-set-mode-abbrev))
      (lambda () (self-insert-command 1)))))
+
+(defun nskk-handle-upper-x ()
+  "Handle X key: purge current candidate from user dictionary.
+In ▼ (conversion) mode, calls `nskk-purge-from-jisyo' to remove the
+current candidate after user confirmation.
+Otherwise delegates to `nskk-self-insert'."
+  (interactive)
+  (if (nskk-converting-p)
+      (nskk-purge-from-jisyo)
+    (nskk-self-insert 1)))
 
 (nskk-define-key-handler x
   "Handle x key: select previous candidate.

--- a/nskk.el
+++ b/nskk.el
@@ -121,6 +121,9 @@
 (declare-function nskk-cancel-conversion-to-reading "nskk-henkan")
 (declare-function nskk-cancel-preedit "nskk-henkan")
 (declare-function nskk--clear-conversion-context "nskk-henkan")
+(declare-function nskk--invalidate-undo-kakutei "nskk-henkan")
+(declare-function nskk-undo-kakutei "nskk-henkan")
+(declare-function nskk-purge-from-jisyo "nskk-henkan")
 (declare-function nskk--commit-by-phase "nskk-keymap")
 
 (defvar nskk-mode-off-hook nil
@@ -160,7 +163,11 @@
   ;; Sticky shift, dynamic completion, numeric input
   ";"       #'nskk-handle-semicolon-key
   "TAB"     #'nskk-handle-tab
-  "#"       #'nskk-handle-hash)
+  "#"       #'nskk-handle-hash
+  ;; Undo-kakutei
+  "C-/"     #'nskk-undo-kakutei
+  ;; Purge candidate from dictionary (DDSKK skk-purge-from-jisyo)
+  "X"       #'nskk-handle-upper-x)
 
 ;;;###autoload
 (define-minor-mode nskk-mode
@@ -330,6 +337,11 @@ relevant phase is already nil and both guards are no-ops."
                (/= (point) nskk--point-before-command)
                (not (memq this-command nskk--bound-commands)))
       (nskk-henkan-kakutei))
+    ;; Invalidate undo-kakutei record when any non-undo command runs.
+    (when (and (not (eq this-command 'nskk-undo-kakutei))
+               (boundp 'nskk--last-kakutei-record)
+               nskk--last-kakutei-record)
+      (nskk--invalidate-undo-kakutei))
     (nskk-modeline-update)))
 
 ;; User commands

--- a/test/integration/nskk-dict-registration-integration-test.el
+++ b/test/integration/nskk-dict-registration-integration-test.el
@@ -304,6 +304,82 @@
             (should nskk-dict-modified)))))))
 
 
+;;;
+;;; Group 4: Dictionary Unregistration (nskk-dict-unregister-word)
+;;;
+
+(nskk-describe "dictionary unregistration"
+
+  (nskk-it "unregistering a sole candidate removes the entire entry"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-given (nskk-dict-register-word "てすと" "テスト"))
+        (nskk-when  (nskk-dict-unregister-word "てすと" "テスト"))
+        (nskk-then  (should (null (nskk-dict-lookup "てすと")))))))
+
+  (nskk-it "unregistering one of multiple candidates keeps others"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-given
+          (nskk-prolog-assert
+           '((user-dict-entry "ふくすう" ("AAA" "BBB" "CCC")))))
+        (nskk-when  (nskk-dict-unregister-word "ふくすう" "BBB"))
+        (nskk-then
+          (let ((candidates (nskk-prolog-query-value
+                             '(user-dict-entry "ふくすう" \?c) '\?c)))
+            (should (member "AAA" candidates))
+            (should (member "CCC" candidates))
+            (should-not (member "BBB" candidates)))))))
+
+  (nskk-it "unregistering a word not in the entry is a no-op"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-given
+          (nskk-prolog-assert
+           '((user-dict-entry "さくら" ("桜")))))
+        (nskk-when
+          (should-not (nskk-dict-unregister-word "さくら" "花")))
+        (nskk-then
+          (should (member "桜" (nskk-dict-lookup "さくら")))))))
+
+  (nskk-it "unregistering from a nonexistent reading is a no-op"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-when
+          (should-not
+           (nskk-dict-unregister-word "ほげ" "ホゲ")))
+        (nskk-then
+          (should (null nskk-dict-modified))))))
+
+  (nskk-it "nskk-dict-modified is set to t after unregistration"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-given
+          (nskk-dict-register-word "にほん" "日本")
+          (setq nskk-dict-modified nil))
+        (nskk-when  (nskk-dict-unregister-word "にほん" "日本"))
+        (nskk-then  (should (eq nskk-dict-modified t))))))
+
+  (nskk-it "register then unregister is a roundtrip"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-given (nskk-dict-register-word "やま" "山"))
+        (nskk-when  (nskk-dict-unregister-word "やま" "山"))
+        (nskk-then  (should (null (nskk-dict-lookup "やま"))))))))
+
+
 (provide 'nskk-dict-registration-integration-test)
 
 ;;; nskk-dict-registration-integration-test.el ends here

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -3959,6 +3959,211 @@
   (nskk-it "returns empty list for empty candidate list"
     (should (equal (nskk--numeric-process-candidates '() "42") '()))))
 
+;;;
+;;; Section: undo-kakutei
+;;;
+
+(nskk-describe "nskk--last-kakutei-record"
+  (nskk-it "is nil by default"
+    (with-temp-buffer
+      (should (null nskk--last-kakutei-record))))
+
+  (nskk-it "can be set and read as a plist"
+    (with-temp-buffer
+      (setq nskk--last-kakutei-record
+            (list :reading "かんじ" :candidates '("漢字")
+                  :index 0 :committed-text "漢字"
+                  :buffer-start 1 :buffer-end 3
+                  :mode 'hiragana :registered-p nil
+                  :registered-reading nil
+                  :registered-word nil))
+      (should (equal "かんじ"
+                     (plist-get nskk--last-kakutei-record
+                                :reading)))
+      (should (equal '("漢字")
+                     (plist-get nskk--last-kakutei-record
+                                :candidates))))))
+
+(nskk-describe "nskk--invalidate-undo-kakutei"
+  (nskk-it "clears a non-nil record"
+    (with-temp-buffer
+      (setq nskk--last-kakutei-record '(:reading "x"))
+      (nskk--invalidate-undo-kakutei)
+      (should (null nskk--last-kakutei-record))))
+
+  (nskk-it "is a no-op when record is already nil"
+    (with-temp-buffer
+      (setq nskk--last-kakutei-record nil)
+      (nskk--invalidate-undo-kakutei)
+      (should (null nskk--last-kakutei-record)))))
+
+(nskk-describe "nskk-undo-kakutei"
+  (nskk-it "falls through to undo when no record exists"
+    (with-temp-buffer
+      (setq nskk--last-kakutei-record nil)
+      ;; undo with no undo info signals user-error
+      (should-error (nskk-undo-kakutei) :type 'user-error)))
+
+  (nskk-it "restores buffer text and sets active phase"
+    (with-temp-buffer
+      (setq-local nskk-current-state (nskk-state-create 'hiragana))
+      (insert "漢字")
+      (setq nskk--last-kakutei-record
+            (list :reading "かんじ"
+                  :candidates '("漢字" "感じ")
+                  :index 0
+                  :committed-text "漢字"
+                  :buffer-start 1
+                  :buffer-end 3
+                  :mode 'hiragana
+                  :registered-p nil
+                  :registered-reading nil
+                  :registered-word nil))
+      (nskk-undo-kakutei)
+      ;; Record should be invalidated
+      (should (null nskk--last-kakutei-record))
+      ;; Phase should be active (▼)
+      (should (eq (nskk-state-henkan-phase nskk-current-state)
+                  'active))
+      ;; Candidates restored
+      (should (equal '("漢字" "感じ")
+                     (nskk-state-candidates nskk-current-state)))
+      ;; Index restored
+      (should (= 0 (nskk-state-current-index nskk-current-state)))
+      ;; Buffer should contain ▼ + candidate
+      (should (string-match-p "▼漢字"
+                              (buffer-substring-no-properties
+                               (point-min) (point-max))))))
+
+  (nskk-it "does not revert when buffer text has changed"
+    (with-temp-buffer
+      (setq-local nskk-current-state (nskk-state-create 'hiragana))
+      (insert "modified")
+      (setq nskk--last-kakutei-record
+            (list :reading "かんじ"
+                  :candidates '("漢字")
+                  :index 0
+                  :committed-text "漢字"
+                  :buffer-start 1
+                  :buffer-end 3
+                  :mode 'hiragana
+                  :registered-p nil
+                  :registered-reading nil
+                  :registered-word nil))
+      (nskk-undo-kakutei)
+      ;; Record invalidated even on mismatch
+      (should (null nskk--last-kakutei-record))
+      ;; Buffer should be unchanged (mismatch guard)
+      (should (equal "modified"
+                     (buffer-substring-no-properties
+                      (point-min) (point-max))))))
+
+  (nskk-it "unregisters a word when registered-p is set"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk--user-dict-index 'user)
+            (nskk-dict-modified nil))
+        (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+        (nskk-dict-register-word "てすと" "テスト")
+        (with-temp-buffer
+          (setq-local nskk-current-state
+                      (nskk-state-create 'hiragana))
+          (insert "テスト")
+          (setq nskk--last-kakutei-record
+                (list :reading "てすと"
+                      :candidates '("テスト")
+                      :index 0
+                      :committed-text "テスト"
+                      :buffer-start 1
+                      :buffer-end 4
+                      :mode 'hiragana
+                      :registered-p t
+                      :registered-reading "てすと"
+                      :registered-word "テスト"))
+          (nskk-undo-kakutei)
+          ;; Word should be unregistered
+          (should (null (nskk-dict-lookup "てすと"))))))))
+
+;;;
+;;; nskk-purge-from-jisyo
+;;;
+
+(nskk-describe "nskk-purge-from-jisyo"
+  (nskk-it "is defined and interactive"
+    (should (fboundp 'nskk-purge-from-jisyo))
+    (should (commandp 'nskk-purge-from-jisyo)))
+
+  (nskk-it "does nothing when not in converting mode"
+    (with-temp-buffer
+      (let ((unregister-called nil))
+        (nskk-with-mocks ((nskk-converting-p (lambda () nil))
+                          (nskk-dict-unregister-word
+                           (lambda (_r _c) (setq unregister-called t))))
+          (nskk-purge-from-jisyo)
+          (should-not unregister-called)))))
+
+  (nskk-it "does nothing when user answers no to confirmation"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (unregister-called nil))
+        (nskk-state-set-candidates nskk-current-state '("候補A" "候補B"))
+        (setf (nskk-state-current-index nskk-current-state) 0)
+        (nskk-state-put-metadata nskk-current-state 'henkan-reading "よみ")
+        (nskk-with-mocks ((nskk-converting-p (lambda () t))
+                          (yes-or-no-p (lambda (_prompt) nil))
+                          (nskk-dict-unregister-word
+                           (lambda (_r _c) (setq unregister-called t))))
+          (nskk-purge-from-jisyo)
+          (should-not unregister-called)))))
+
+  (nskk-it "purges candidate and updates state when multiple remain"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (unregistered-reading nil)
+            (unregistered-candidate nil)
+            (overlay-updated nil))
+        (nskk-state-set-candidates nskk-current-state '("候補A" "候補B" "候補C"))
+        (setf (nskk-state-current-index nskk-current-state) 0)
+        (nskk-state-put-metadata nskk-current-state 'henkan-reading "よみ")
+        (nskk-with-mocks ((nskk-converting-p (lambda () t))
+                          (yes-or-no-p (lambda (_prompt) t))
+                          (nskk-dict-unregister-word
+                           (lambda (r c)
+                             (setq unregistered-reading r
+                                   unregistered-candidate c)))
+                          (nskk--update-overlay
+                           (lambda (_start _end _text)
+                             (setq overlay-updated t)))
+                          (nskk--get-conversion-start (lambda () 1))
+                          (overlay-end (lambda (_ov) 10)))
+          (let ((nskk--conversion-overlay (make-overlay 1 1))
+                (nskk-henkan-active-marker "▼"))
+            (nskk-purge-from-jisyo)
+            ;; Should have called unregister with correct args
+            (should (equal unregistered-reading "よみ"))
+            (should (equal unregistered-candidate "候補A"))
+            ;; Candidates should be updated (候補A removed)
+            (should (equal (nskk-state-candidates nskk-current-state)
+                           '("候補B" "候補C")))
+            ;; Index should be adjusted
+            (should (= (nskk-state-current-index nskk-current-state) 0))
+            ;; Overlay should be updated
+            (should overlay-updated))))))
+
+  (nskk-it "cancels conversion when purging the last candidate"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (cancel-called nil))
+        (nskk-state-set-candidates nskk-current-state '("唯一"))
+        (setf (nskk-state-current-index nskk-current-state) 0)
+        (nskk-state-put-metadata nskk-current-state 'henkan-reading "ゆいいつ")
+        (nskk-with-mocks ((nskk-converting-p (lambda () t))
+                          (yes-or-no-p (lambda (_prompt) t))
+                          (nskk-dict-unregister-word #'ignore)
+                          (nskk-cancel-conversion-to-reading
+                           (lambda () (setq cancel-called t))))
+          (nskk-purge-from-jisyo)
+          (should cancel-called))))))
+
 (provide 'nskk-henkan-test)
 
 ;;; nskk-henkan-test.el ends here

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -399,6 +399,31 @@ NAV-FN is the fallthrough navigation command symbol (e.g. `forward-char')."
            (should (string-suffix-p "L" (buffer-string)))))))))
 
 ;;;
+;;; nskk-handle-upper-x behavior
+;;;
+
+(nskk-describe "nskk-handle-upper-x behavior"
+  (nskk-it "is defined and interactive"
+    (should (fboundp 'nskk-handle-upper-x))
+    (should (commandp 'nskk-handle-upper-x)))
+
+  (nskk-it "calls nskk-purge-from-jisyo when converting"
+    (let ((purge-called nil))
+      (nskk-with-mocks ((nskk-converting-p (lambda () t))
+                        (nskk-purge-from-jisyo
+                         (lambda () (setq purge-called t))))
+        (nskk-handle-upper-x)
+        (should purge-called))))
+
+  (nskk-it "calls nskk-self-insert when not converting"
+    (let ((self-insert-called nil))
+      (nskk-with-mocks ((nskk-converting-p (lambda () nil))
+                        (nskk-self-insert
+                         (lambda (_n) (setq self-insert-called t))))
+        (nskk-handle-upper-x)
+        (should self-insert-called)))))
+
+;;;
 ;;; nskk-handle-slash behavior
 ;;;
 


### PR DESCRIPTION
## Summary
- **undo-kakutei** (`C-/`): Revert the most recent kakutei, restoring ▼ conversion mode with original candidates. Supports registration undo (auto-unregisters word from user dict). Invalidated by any subsequent command via post-command-hook.
- **dict-unregister**: `defun/k` CPS function + Prolog `dict-unregister/2` rule to remove candidates from user dictionary (sole-candidate retract + multi-candidate element removal).
- **purge-from-jisyo** (`X` key): DDSKK `skk-purge-from-jisyo` equivalent — interactively purge current candidate from user dictionary during ▼ mode with `yes-or-no-p` confirmation.

## Test plan
- [x] 22 new tests (unit + integration): 5454/5454 passing
- [x] Zero byte-compile warnings
- [x] Interactive debugging via emacs daemon confirmed all features work
- [x] Keybindings verified: `C-/` → `nskk-undo-kakutei`, `X` → `nskk-handle-upper-x`
- [x] README keybinding table updated