### PR TITLE
fix: correct DDSKK description in Acknowledgments

### DIFF
--- a/README.org
+++ b/README.org
@@ -327,5 +327,5 @@ the Free Software Foundation, either version 3 of the License, or
 #+end_quote
 * Acknowledgments
 
-- [[https://github.com/skk-dev/ddskk][DDSKK]] — The original SKK implementation
+- [[https://github.com/skk-dev/ddskk][DDSKK]] — A long-standing and widely used SKK implementation for Emacs
 - All SKK dictionary contributors


### PR DESCRIPTION
## Summary

- DDSKK の説明を「The original SKK implementation」から「A long-standing and widely used SKK implementation for Emacs」に修正
- オリジナルの SKK は 1987 年に京都大学の佐藤雅彦先生が作成したもので、DDSKK (Daredevil SKK) は SKK Openlab が v11.1 から引き継いで開発している後継実装

## Reference

- https://ddskk.readthedocs.io/ja/latest/10_FAQ.html#q1-1-daredevil-skk-skk
- https://github.com/skk-dev/ddskk/blob/master/READMEs/history.md