### PR TITLE
fix: AZIK q key inserts ん in preedit instead of katakana conversion

### DIFF
--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -525,11 +525,8 @@ Falls through to `self-insert-command' when not in a Japanese input mode."
 (defun/done nskk-handle-q ()
   "Handle q key: convert preedit kana to opposite script, or toggle mode.
 In ▽ preedit phase (hiragana/katakana Japanese mode):
-  - AZIK mode + pending romaji: delegates to `nskk-handle-q-key' so that
-    AZIK romaji rules take priority (e.g. \"tq\" → \"たい\").
-  - AZIK mode + empty romaji: converts the accumulated kana to the opposite
-    script via `nskk-henkan-kakutei-convert-script' (same as standard mode).
-    Enables e.g. A:q → アー (type kana with ー, then q to commit as katakana).
+  - AZIK mode: always delegates to `nskk-handle-q-key' so that AZIK romaji
+    rules take priority (e.g. \"tq\" → \"たい\", standalone q → ん).
   - Standard mode: converts the accumulated kana to the opposite script via
     `nskk-henkan-kakutei-convert-script' and commits without changing the
     input mode.
@@ -548,7 +545,8 @@ Dispatched via `q-key-dispatch/3' Prolog table."
                   `(q-key-dispatch ,cls ,style \?a) '\?a)))
     (pcase action
       ('fire-romaji     (if (and (eq cls 'preedit-japanese)
-                                 (string-empty-p nskk--romaji-buffer))
+                                 (string-empty-p nskk--romaji-buffer)
+                                 (not (eq style 'azik)))
                             (nskk-henkan-kakutei-convert-script)
                           (nskk-handle-q-key)))
       ('convert-script  (nskk-henkan-kakutei-convert-script))

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -785,13 +785,13 @@ This ensures:
       (nskk-e2e-assert-henkan-phase 'on "▽ must remain active after Katq")
       (nskk-e2e-assert-mode 'hiragana "mode must not change after tq in AZIK ▽ preedit")))
 
-  (nskk-it "Kaq: standalone q in ▽ preedit converts to katakana and commits"
-    ;; Ka → ▽ か; q → romaji buffer empty → convert-script → commits カ.
-    ;; ▽ mode ends; buffer contains カ.
+  (nskk-it "Kaq: standalone q in AZIK ▽ preedit inserts ん (not katakana conversion)"
+    ;; Ka → ▽ か; q → romaji buffer empty → AZIK q inserts ん → ▽かん.
+    ;; ▽ mode must remain active; AZIK q = ん, katakana via toggle key.
     (nskk-e2e-with-azik-buffer 'hiragana nil
       (nskk-e2e-type "Kaq")
-      (nskk-e2e-assert-henkan-phase nil "▽ must end after Kaq convert-script")
-      (nskk-e2e-assert-buffer "カ" "Kaq must commit カ (hiragana→katakana)")))
+      (nskk-e2e-assert-henkan-phase 'on "▽ must remain active after Kaq")
+      (nskk-e2e-assert-buffer "▽かん" "Kaq must produce かん (q=ん in AZIK)")))
 
   (nskk-it "Sq: q fires sq→さい as first char after henkan start (preedit-pending state)"
     ;; Regression: S → ▽ (preedit-pending, romaji="s"); q was self-inserted
@@ -814,13 +814,23 @@ This ensures:
       (nskk-e2e-assert-henkan-phase 'on "▽ must remain active after Kq")
       (nskk-e2e-assert-buffer "▽かい" "Kq must produce かい via AZIK diphthong rule")))
 
-  (nskk-it "A:q → アー (AZIK colon ー then q converts to katakana)"
+  (nskk-it "A:q → ▽あーん (AZIK colon ー then q inserts ん)"
     ;; A → ▽あ; : → AZIK plain-vowel path → ー appended → ▽あー;
-    ;; q → romaji buffer empty → convert-script → commits アー.
+    ;; q → romaji buffer empty → AZIK q inserts ん → ▽あーん.
+    ;; In AZIK, katakana conversion uses toggle key (@/[), not q.
     (nskk-e2e-with-azik-buffer 'hiragana nil
       (nskk-e2e-type "A:q")
-      (nskk-e2e-assert-henkan-phase nil "▽ must end after A:q")
-      (nskk-e2e-assert-buffer "アー" "A:q must commit アー"))))
+      (nskk-e2e-assert-henkan-phase 'on "▽ must remain active after A:q")
+      (nskk-e2e-assert-buffer "▽あーん" "A:q must produce あーん (q=ん in AZIK)")))
+
+  (nskk-it "Dezqq: double-vowel then standalone q inserts ん in ▽ preedit"
+    ;; D → ▽ d pending; e → de→で; z → z pending; q → zq→ざい (AZIK);
+    ;; q → romaji empty → AZIK q inserts ん → ▽でざいん.
+    ;; Regression: second q was triggering katakana conversion (デザイ).
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "Dezqq")
+      (nskk-e2e-assert-henkan-phase 'on "▽ must remain active after Dezqq")
+      (nskk-e2e-assert-buffer "▽でざいん" "Dezqq must produce でざいん (second q=ん)"))))
 
 ;;;;
 ;;;; Section 13: AZIK Okurigana with AZIK Kana Shortcuts — Double-* Regression

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -266,7 +266,36 @@ NAV-FN is the fallthrough navigation command symbol (e.g. `forward-char')."
           (nskk-when (nskk-handle-q))
           (nskk-then
            (should (eq (nskk-state-mode nskk-current-state) 'abbrev))
-           (should (string-suffix-p "q" (buffer-string)))))))))
+           (should (string-suffix-p "q" (buffer-string))))))))
+
+  (nskk-context "AZIK preedit q dispatch"
+    (nskk-it "delegates to nskk-handle-q-key in AZIK preedit with empty romaji"
+      (with-temp-buffer
+        (let ((nskk-current-state (nskk-state-create 'hiragana))
+              (nskk-converter-romaji-style 'azik)
+              (nskk--romaji-buffer "")
+              (delegated nil))
+          (nskk--set-conversion-start-marker (point-min))
+          (insert "▽か")
+          (nskk-state-set-henkan-phase nskk-current-state 'on)
+          (cl-letf (((symbol-function 'nskk-handle-q-key) (lambda () (setq delegated t)))
+                    ((symbol-function 'nskk-henkan-kakutei-convert-script) (lambda () (error "must not call"))))
+            (nskk-handle-q))
+          (should delegated))))
+
+    (nskk-it "calls convert-script in standard preedit with empty romaji"
+      (with-temp-buffer
+        (let ((nskk-current-state (nskk-state-create 'hiragana))
+              (nskk-converter-romaji-style 'roman)
+              (nskk--romaji-buffer "")
+              (converted nil))
+          (nskk--set-conversion-start-marker (point-min))
+          (insert "▽か")
+          (nskk-state-set-henkan-phase nskk-current-state 'on)
+          (cl-letf (((symbol-function 'nskk-henkan-kakutei-convert-script) (lambda () (setq converted t)))
+                    ((symbol-function 'nskk-handle-q-key) (lambda () (error "must not call"))))
+            (nskk-handle-q))
+          (should converted))))))
 
 ;;;
 ;;; nskk-handle-l behavior


### PR DESCRIPTION
## Summary
- AZIK mode で ▽ preedit 中に romaji buffer が空の状態で `q` を押すとカタカナ変換されていたバグを修正
- `nskk-handle-q` の `fire-romaji` ディスパッチに `(not (eq style 'azik))` ガードを追加
- AZIK では `q` = ん、カタカナ変換は `@`/`[` トグルキーで行う (DDSKK互換)

## Example
- Before: `Dezqq` → `デザイ` (2nd q triggers katakana conversion)
- After: `Dezqq` → `▽でざいん` (2nd q inserts ん)

## Test plan
- [x] Unit tests: AZIK dispatch delegates to `nskk-handle-q-key`, standard mode regression guard
- [x] E2E tests: `Dezqq` → `▽でざいん`, `Kaq` → `▽かん`, `A:q` → `▽あーん`
- [x] Full test suite: 5495/5495 pass (0 failures)