### PR TITLE
fix: BS in preedit deletes pending romaji before committed kana

### DIFF
--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -114,6 +114,11 @@
 (declare-function nskk--try-candidate-selection/k "nskk-input" (char on-found on-not-found))
 (defvar nskk-converter-romaji-style)
 (defvar nskk--romaji-buffer)          ;; Forward declaration from nskk-state.el
+;; AZIK deferred state variables from nskk-input.el
+(defvar nskk--deferred-azik-state)
+(defvar nskk--deferred-vowel-shadow-state)
+(defvar nskk--azik-colon-okuri-pending)
+(defvar nskk--azik-colon-okuri-deferred)
 ;; Functions in nskk-henkan.el
 (declare-function nskk-converting-p "nskk-henkan")
 (declare-function nskk--has-preedit "nskk-henkan")
@@ -127,6 +132,9 @@
 (declare-function nskk-rollback-conversion "nskk-henkan")
 (declare-function nskk-cancel-preedit "nskk-henkan")
 (declare-function nskk--clear-azik-pending-state "nskk-henkan")
+(declare-function nskk--show-pending-romaji "nskk-henkan")
+(declare-function nskk--clear-pending-romaji "nskk-henkan")
+(declare-function nskk--reset-romaji-buffer "nskk-henkan")
 (declare-function nskk-henkan-kakutei "nskk-henkan")
 (declare-function nskk-henkan-kakutei-convert-script "nskk-henkan")
 (declare-function nskk-dynamic-complete "nskk-henkan")
@@ -719,20 +727,46 @@ Otherwise clears any residual AZIK deferred state and calls
   (_ (nskk--clear-azik-pending-state) (keyboard-quit)))
 
 (defun nskk--backspace-in-preedit ()
-  "Delete the last preedit character, or cancel preedit if empty.
+  "Delete pending romaji, AZIK deferred state, or last preedit char.
 Called when backspace is pressed in preedit state.
-If point is beyond the marker content area, deletes one character
-backward with `delete-char'.  If the preedit area is empty (marker in
-buffer but no characters typed yet), cancels the entire preedit via
-`nskk-cancel-preedit'.
-
-If point drifted to the left of the preedit boundary, do not delete any
-buffer text; move point back to the preedit boundary instead.  This is
-the safe-side behavior to avoid deleting already-committed text."
+Priority: DA > DV > CP > CD > romaji-buffer > buffer text.
+If point drifted left of preedit boundary, clamp it instead."
   (let* ((start (nskk--get-conversion-start))
          (preedit-min (and start (+ start (length nskk-henkan-on-marker)))))
     (when preedit-min
       (cond
+       ;; 1. DA: deferred-azik-state -- delete tentative kana
+       ((and (boundp 'nskk--deferred-azik-state) nskk--deferred-azik-state)
+        (delete-char (- (length (cdr nskk--deferred-azik-state))))
+        (setq nskk--deferred-azik-state nil)
+        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
+       ;; 2. DV: deferred-vowel-shadow-state -- delete tentative kana
+       ((and (boundp 'nskk--deferred-vowel-shadow-state)
+             nskk--deferred-vowel-shadow-state)
+        (delete-char (- (length (cdr nskk--deferred-vowel-shadow-state))))
+        (setq nskk--deferred-vowel-shadow-state nil)
+        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
+       ;; 3. CP: colon-okuri-pending -- delete `*' marker
+       ((and (boundp 'nskk--azik-colon-okuri-pending)
+             nskk--azik-colon-okuri-pending)
+        (delete-char -1)
+        (setq nskk--azik-colon-okuri-pending nil)
+        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
+       ;; 4. CD: colon-okuri-deferred -- delete placeholder, reset romaji
+       ((and (boundp 'nskk--azik-colon-okuri-deferred)
+             nskk--azik-colon-okuri-deferred)
+        (delete-char (- (length (cdr nskk--azik-colon-okuri-deferred))))
+        (setq nskk--azik-colon-okuri-deferred nil)
+        (nskk--reset-romaji-buffer)
+        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
+       ;; 5. Non-empty romaji buffer -- delete last char, update overlay
+       ((and (boundp 'nskk--romaji-buffer)
+             (not (string-empty-p nskk--romaji-buffer)))
+        (setq nskk--romaji-buffer (substring nskk--romaji-buffer 0 -1))
+        (if (string-empty-p nskk--romaji-buffer)
+            (nskk--clear-pending-romaji)
+          (nskk--show-pending-romaji nskk--romaji-buffer)))
+       ;; 6. Existing logic -- delete committed kana or cancel
        ((> (point) preedit-min)
         (delete-char -1))
        ((= (point) preedit-min)

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -1502,6 +1502,76 @@ This ensures:
       (nskk-e2e-type input)
       (nskk-e2e-assert-buffer expected))))
 
+;;;;
+;;;; Section 20: Backspace with AZIK Deferred State in Preedit
+;;;;
+
+(nskk-describe "§20: DEL clears AZIK deferred state in preedit (backspace-in-preedit bug)"
+
+  (nskk-it "T-01: DEL rolls back tentative きん from DA (kk in preedit)"
+    ;; In AZIK mode: type K (preedit), then "k" (triggers DA: tentative きん).
+    ;; State: ▽きん (DA active, nskk--deferred-azik-state is non-nil).
+    ;; Press BS: should clear DA and delete tentative きん.
+    ;; Since きん was the only content after ▽, preedit is cancelled entirely.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "K")
+      (nskk-e2e-type "k")
+      (nskk-e2e-assert-henkan-phase 'on "After 'Kk': should be in ▽ preedit")
+      (should (bound-and-true-p nskk--deferred-azik-state))
+      ;; Press DEL: should clear DA, delete tentative kana, cancel preedit.
+      (nskk-e2e-type "DEL")
+      (should (not (bound-and-true-p nskk--deferred-azik-state)))
+      (nskk-e2e-assert-henkan-phase nil "After DEL of DA: preedit cancelled (no content left)")
+      (nskk-e2e-assert-buffer "" "After DEL of DA: buffer empty")))
+
+  (nskk-it "T-02: DEL rolls back tentative すう from DV (sh in preedit)"
+    ;; In AZIK mode: type S (preedit), then "h" (triggers DV: tentative すう).
+    ;; State: ▽すう (DV active, nskk--deferred-vowel-shadow-state is non-nil).
+    ;; Press BS: should clear DV and delete tentative すう.
+    ;; Since すう was the only content after ▽, preedit is cancelled entirely.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "S")
+      (nskk-e2e-type "h")
+      (nskk-e2e-assert-henkan-phase 'on "After 'Sh': should be in ▽ preedit")
+      (should (bound-and-true-p nskk--deferred-vowel-shadow-state))
+      ;; Press DEL: should clear DV, delete tentative kana, cancel preedit.
+      (nskk-e2e-type "DEL")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))
+      (nskk-e2e-assert-henkan-phase nil "After DEL of DV: preedit cancelled (no content left)")
+      (nskk-e2e-assert-buffer "" "After DEL of DV: buffer empty")))
+
+  (nskk-it "T-03: DEL with DA preserves prior kana in preedit (kakk)"
+    ;; Type "Kakk": K starts preedit, "a" produces か, "kk" triggers DA (きん tentative).
+    ;; State: ▽かきん (DA active).
+    ;; Press BS: should clear DA and delete tentative きん, leaving ▽か.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "K")
+      (nskk-e2e-type "a")
+      (nskk-e2e-type "k")
+      (nskk-e2e-type "k")
+      (nskk-e2e-assert-henkan-phase 'on "After 'Kakk': should be in ▽ preedit")
+      (should (bound-and-true-p nskk--deferred-azik-state))
+      (nskk-e2e-type "DEL")
+      (should (not (bound-and-true-p nskk--deferred-azik-state)))
+      (nskk-e2e-assert-henkan-phase 'on "After DEL of DA: preedit survives with prior kana")
+      (nskk-e2e-assert-buffer "▽か" "After DEL of DA: tentative きん removed, か remains")))
+
+  (nskk-it "T-04: DEL with DV preserves prior kana in preedit (kash)"
+    ;; Type "Kash": K starts preedit, "a" produces か, "sh" triggers DV (すう tentative).
+    ;; State: ▽かすう (DV active).
+    ;; Press BS: should clear DV and delete tentative すう, leaving ▽か.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "K")
+      (nskk-e2e-type "a")
+      (nskk-e2e-type "s")
+      (nskk-e2e-type "h")
+      (nskk-e2e-assert-henkan-phase 'on "After 'Kash': should be in ▽ preedit")
+      (should (bound-and-true-p nskk--deferred-vowel-shadow-state))
+      (nskk-e2e-type "DEL")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))
+      (nskk-e2e-assert-henkan-phase 'on "After DEL of DV: preedit survives with prior kana")
+      (nskk-e2e-assert-buffer "▽か" "After DEL of DV: tentative すう removed, か remains"))))
+
 (provide 'nskk-azik-e2e-test)
 
 ;;; nskk-azik-e2e-test.el ends here

--- a/test/e2e/nskk-henkan-e2e-test.el
+++ b/test/e2e/nskk-henkan-e2e-test.el
@@ -1183,7 +1183,42 @@ Indices 0-10: 漢字 感じ 幹事 換字 貫地 刊事 肝事 感事 看事 官
       (goto-char (point-min))
       (nskk-e2e-type "DEL")
       (nskk-e2e-assert-buffer "A▽か" "DEL must not delete committed text when point drifted left")
-      (should (= (point) (+ 2 (length nskk-henkan-on-marker)))))))
+      (should (= (point) (+ 2 (length nskk-henkan-on-marker))))))
+
+  (nskk-it "deletes pending romaji instead of committed kana (backspace-in-preedit bug)"
+    ;; Bug reproduction: typing K (preedit), "a" (produces か), "g" (pending romaji).
+    ;; State: ▽かg — "g" is in romaji buffer, shown via overlay.
+    ;; Old behavior: BS deleted か (the committed kana) instead of clearing "g".
+    ;; Fixed behavior: BS clears "g" from romaji buffer, leaving ▽か.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "K")
+      (nskk-e2e-type "a")
+      (nskk-e2e-type "g")
+      (nskk-e2e-assert-henkan-phase 'on "After 'Kag': should be in ▽ preedit")
+      ;; Romaji buffer should contain "g" (pending consonant).
+      (should (equal nskk--romaji-buffer "g"))
+      ;; Press BS: should clear pending romaji, NOT delete committed kana.
+      (nskk-e2e-type "DEL")
+      (nskk-e2e-assert-buffer "▽か" "DEL with pending romaji: must clear romaji, not delete kana")
+      (should (equal nskk--romaji-buffer ""))
+      (nskk-e2e-assert-henkan-phase 'on "After DEL of pending romaji: still in ▽ preedit")))
+
+  (nskk-it "deletes committed kana when no pending romaji (existing behavior preserved)"
+    ;; Type K, then "a" (produces か) — no pending romaji.
+    ;; First BS: deletes か, leaving ▽ (empty preedit).
+    ;; Second BS: cancels preedit entirely.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "Ka")
+      (nskk-e2e-assert-henkan-phase 'on "After 'Ka': should be in ▽ preedit")
+      (should (equal nskk--romaji-buffer ""))
+      ;; First DEL: no pending romaji, so delete committed kana か.
+      (nskk-e2e-type "DEL")
+      (nskk-e2e-assert-buffer "▽" "1st DEL with no pending romaji: delete committed kana")
+      (nskk-e2e-assert-henkan-phase 'on "After 1st DEL: still in ▽ preedit")
+      ;; Second DEL: empty preedit, cancel entirely.
+      (nskk-e2e-type "DEL")
+      (nskk-e2e-assert-henkan-phase nil "After 2nd DEL: preedit cancelled")
+      (nskk-e2e-assert-buffer "" "After 2nd DEL: buffer is empty"))))
 
 ;;;;
 ;;;; DEL in Normal State (No Preedit, No Conversion)

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -1067,7 +1067,176 @@ and configures state."
             (should (= (point) 3))
             (should (equal (buffer-string) "A▽ka"))
             (should-not cancel-called)
-            (should-not delete-called)))))))
+            (should-not delete-called))))))
+
+  (nskk-it "BS clears single-char romaji buffer"
+    (let ((clear-called nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () (point-min)))
+                        (nskk--clear-pending-romaji (lambda () (setq clear-called t))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "g"))
+            (insert "▽ほ")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should (equal nskk--romaji-buffer ""))
+            (should clear-called)
+            (should (equal (buffer-string) "▽ほ")))))))
+
+  (nskk-it "BS truncates multi-char romaji buffer"
+    (let ((show-arg nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () (point-min)))
+                        (nskk--show-pending-romaji (lambda (s) (setq show-arg s))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "ky"))
+            (insert "▽ほ")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should (equal nskk--romaji-buffer "k"))
+            (should (equal show-arg "k"))
+            (should (equal (buffer-string) "▽ほ")))))))
+
+  (nskk-it "BS truncates romaji \"k\" to empty and clears pending"
+    (let ((clear-called nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () (point-min)))
+                        (nskk--clear-pending-romaji (lambda () (setq clear-called t))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "k"))
+            (insert "▽ほ")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should (equal nskk--romaji-buffer ""))
+            (should clear-called)
+            (should (equal (buffer-string) "▽ほ")))))))
+
+  (nskk-it "BS rolls back DA (deferred-azik-state)"
+    (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                      (nskk-cancel-preedit (lambda () nil)))
+      (with-temp-buffer
+        (let ((nskk-henkan-on-marker "▽")
+              (nskk--romaji-buffer "")
+              (nskk--deferred-azik-state (cons ?k "きん")))
+          (insert "▽きん")
+          (goto-char (point-max))
+          (nskk--backspace-in-preedit)
+          (should-not nskk--deferred-azik-state)
+          (should (equal (buffer-string) "▽"))))))
+
+  (nskk-it "BS rolls back DV (deferred-vowel-shadow-state)"
+    (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                      (nskk-cancel-preedit (lambda () nil)))
+      (with-temp-buffer
+        (let ((nskk-henkan-on-marker "▽")
+              (nskk--romaji-buffer "")
+              (nskk--deferred-vowel-shadow-state (cons "sh" "すう")))
+          (insert "▽すう")
+          (goto-char (point-max))
+          (nskk--backspace-in-preedit)
+          (should-not nskk--deferred-vowel-shadow-state)
+          (should (equal (buffer-string) "▽"))))))
+
+  (nskk-it "BS rolls back CP (colon-okuri-pending) deletes * marker"
+    (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1)))
+      (with-temp-buffer
+        (let ((nskk-henkan-on-marker "▽")
+              (nskk--romaji-buffer "")
+              (nskk--azik-colon-okuri-pending t))
+          (insert "▽ほ*")
+          (goto-char (point-max))
+          (nskk--backspace-in-preedit)
+          (should-not nskk--azik-colon-okuri-pending)
+          (should (equal (buffer-string) "▽ほ"))))))
+
+  (nskk-it "BS rolls back CD (colon-okuri-deferred) deletes placeholder and resets romaji"
+    (let ((reset-called nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                        (nskk--reset-romaji-buffer (lambda () (setq reset-called t))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "t")
+                (nskk--azik-colon-okuri-deferred (cons ?t "t")))
+            (insert "▽ほ*t")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should-not nskk--azik-colon-okuri-deferred)
+            (should reset-called)
+            (should (equal (buffer-string) "▽ほ*")))))))
+
+  (nskk-it "DA rollback causes empty preedit triggers cancel-preedit"
+    (let ((cancel-called nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                        (nskk-cancel-preedit (lambda () (setq cancel-called t))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "")
+                (nskk--deferred-azik-state (cons ?k "きん")))
+            (insert "▽きん")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should cancel-called))))))
+
+  (nskk-it "romaji empty and committed kana calls delete-char"
+    (let ((deleted nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                        (delete-char (lambda (n) (setq deleted n))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "")
+                (nskk--deferred-azik-state nil)
+                (nskk--deferred-vowel-shadow-state nil)
+                (nskk--azik-colon-okuri-pending nil)
+                (nskk--azik-colon-okuri-deferred nil))
+            (insert "▽か")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should (equal deleted -1)))))))
+
+  (nskk-it "romaji empty and preedit empty calls cancel-preedit"
+    (let ((cancel-called nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                        (nskk-cancel-preedit (lambda () (setq cancel-called t))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "")
+                (nskk--deferred-azik-state nil)
+                (nskk--deferred-vowel-shadow-state nil)
+                (nskk--azik-colon-okuri-pending nil)
+                (nskk--azik-colon-okuri-deferred nil))
+            (insert "▽")
+            (goto-char (point-max))
+            (nskk--backspace-in-preedit)
+            (should cancel-called))))))
+
+  (nskk-it "consecutive BS reduces romaji then deletes kana"
+    (let ((show-called nil)
+          (clear-called nil)
+          (deleted nil))
+      (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
+                        (nskk--show-pending-romaji (lambda (_s) (setq show-called t)))
+                        (nskk--clear-pending-romaji (lambda () (setq clear-called t)))
+                        (delete-char (lambda (n) (setq deleted n))))
+        (with-temp-buffer
+          (let ((nskk-henkan-on-marker "▽")
+                (nskk--romaji-buffer "ky")
+                (nskk--deferred-azik-state nil)
+                (nskk--deferred-vowel-shadow-state nil)
+                (nskk--azik-colon-okuri-pending nil)
+                (nskk--azik-colon-okuri-deferred nil))
+            (insert "▽ほ")
+            (goto-char (point-max))
+            ;; First BS: "ky" -> "k", show-pending called
+            (nskk--backspace-in-preedit)
+            (should (equal nskk--romaji-buffer "k"))
+            (should show-called)
+            ;; Second BS: "k" -> "", clear-pending called
+            (nskk--backspace-in-preedit)
+            (should (equal nskk--romaji-buffer ""))
+            (should clear-called)
+            ;; Third BS: romaji empty, committed kana -> delete-char
+            (nskk--backspace-in-preedit)
+            (should (equal deleted -1))))))))
 
 ;;;
 ;;; nskk-handle-tab behavior


### PR DESCRIPTION
## Summary
- When pressing BS in preedit with pending romaji (e.g., `▽ほg`), the committed kana `ほ` was deleted instead of the pending `g`
- `nskk--backspace-in-preedit` now checks AZIK deferred state and romaji buffer before falling through to `delete-char`
- Priority order: DA > DV > CP > CD > romaji-buffer > buffer text
- Romaji buffer is deleted char-by-char (`ky`→`k`→empty); AZIK deferred state rolls back tentative kana atomically

## Test plan
- [x] 11 unit tests for all BS priority branches (romaji, DA, DV, CP, CD, existing behavior)
- [x] 2 E2E tests for normal preedit BS (bug reproduction + regression)
- [x] 4 AZIK E2E tests (§20: DA/DV rollback with/without prior kana)
- [x] Full suite: 5512/5512 pass, byte-compile 0 warnings
- [x] Daemon manual verification: `▽ほg` + BS correctly clears `g`