### PR TITLE
feat: sticky key immediately inserts ▽ on semicolon press

### DIFF
--- a/nskk-input.el
+++ b/nskk-input.el
@@ -116,6 +116,7 @@
 (declare-function nskk--flush-romaji-before-okuri "nskk-henkan")
 (declare-function nskk-state-henkan-phase "nskk-state")
 (declare-function nskk--clear-conversion-context "nskk-henkan")
+(declare-function nskk-cancel-preedit "nskk-henkan")
 (declare-function nskk--show-pending-romaji "nskk-henkan" (text))
 (declare-function nskk--clear-pending-romaji "nskk-henkan" ())
 (defvar nskk--romaji-buffer)                         ;; Forward declaration from nskk-state.el
@@ -130,7 +131,11 @@
 (defvar nskk-azik-keyboard-type)                     ;; Forward declaration from nskk-azik.el
 
 (defvar-local nskk--sticky-shift-pending nil
-  "Non-nil when sticky shift is pending (next char treated as uppercase).")
+  "Non-nil when sticky shift is pending.
+Value is a symbol:
+  nil         -- not pending
+  `immediate' -- ▽ just inserted by sticky key, awaiting ;; detection
+  `okurigana' -- armed for okurigana (next char upcased for okurigana boundary)")
 
 (defvar nskk--azik-vowel-shadow-set)    ;; Forward declaration from nskk-azik.el
 
@@ -361,34 +366,62 @@ In standard mode: toggle mode (default SKK behavior)."
 
 (defun nskk--sticky-shift-dispatch ()
   "Execute the sticky-shift sub-dispatch for semicolon in standard mode.
-Three arms in priority order:
-  1. Already pending: double-semicolon cancels sticky shift and inserts \";\".
-  2. Japanese mode active: arm the sticky-shift pending flag.
-  3. Non-Japanese mode: fall through to self-insert.
-Returns non-nil when the sticky-shift action was consumed (arms 1 or 2),
-nil when falling through to self-insert (arm 3)."
+Six arms in priority order:
+  1. Already pending (any value): double-semicolon cancels sticky shift,
+     cancels preedit if ▽ was just inserted, and inserts literal \";\".
+  2. Converting (▼) state: fall through to self-insert.
+  3. Preedit with kana (▽ + text): arm okurigana for next char.
+  4. Preedit-pending (▽ without kana): cancel preedit, insert \";\".
+  5. Japanese mode, no preedit: immediately insert ▽ marker.
+  6. Non-Japanese mode: fall through to self-insert.
+Returns non-nil when the sticky-shift action was consumed,
+nil when falling through to self-insert."
   (cond
+   ;; Arm 1: double-semicolon cancel
    (nskk--sticky-shift-pending
-    (setq nskk--sticky-shift-pending nil)
+    (let ((was-immediate (eq nskk--sticky-shift-pending 'immediate)))
+      (setq nskk--sticky-shift-pending nil)
+      (when was-immediate
+        (nskk-cancel-preedit))
+      (insert ";")
+      t))
+   ;; Arm 2: converting (▼) state — fall through
+   ((and nskk-current-state
+         (nskk-state-p nskk-current-state)
+         (nskk-prolog-holds-p
+          `(converting-phase ,(nskk-state-henkan-phase nskk-current-state))))
+    nil)
+   ;; Arm 3: preedit with kana — arm okurigana
+   ((and (nskk--conversion-start-active-p)
+         (nskk--has-preedit))
+    (setq nskk--sticky-shift-pending 'okurigana)
+    t)
+   ;; Arm 4: preedit-pending (▽ without kana) — cancel + insert ";"
+   ((nskk--conversion-start-active-p)
+    (nskk-cancel-preedit)
     (insert ";")
     t)
+   ;; Arm 5: Japanese mode, no preedit — immediate ▽
    ((and nskk-current-state
          (nskk-prolog-holds-p
           `(japanese-mode ,(nskk-state-mode nskk-current-state))))
-    (setq nskk--sticky-shift-pending t)
+    (nskk--setup-henkan-start-marker ?\;)
+    (setq nskk--sticky-shift-pending 'immediate)
     t)
+   ;; Arm 6: non-Japanese — fall through
    (t nil)))
 
 ;;;###autoload
 (defun/k nskk-handle-semicolon-key ()
   "Handle semicolon key press.
 In AZIK mode: produce small tsu (\u3063).
-In standard mode + Japanese mode: sticky shift (next char is uppercase).
+In standard mode + idle Japanese: immediately insert ▽ (sticky shift).
+In standard mode + preedit with kana: arm okurigana for next char.
 Double semicolon in sticky-shift state: cancel sticky, insert literal \";\".
 In standard mode + non-Japanese mode: self-insert (on-not-found path).
 
 `on-found' is called (with t) when the key was consumed as a Japanese action:
-  AZIK small-tsu insertion, sticky-shift armed, or sticky-shift cancelled.
+  AZIK small-tsu insertion, immediate ▽, okurigana armed, or sticky cancelled.
 `on-not-found' is called when key is not consumed (self-insert path)."
   :interactive t
   (let* ((style (if (eq nskk-converter-romaji-style 'azik) 'azik 'standard))
@@ -521,7 +554,8 @@ Calls on-not-found when the list is not active or CHAR did not match."
   "Set up conversion start marker for CHAR as a henkan start.
 Inserts the ▽ marker, sets conversion start position at point,
 and marks henkan phase to `on'.
-Called when an uppercase letter triggers auto-henkan-start."
+Called when an uppercase letter triggers auto-henkan-start, or
+when the sticky key immediately enters ▽ mode (CHAR = ?\\;)."
   (nskk-debug-log "[INPUT] henkan-start: char=%c" char)
   (nskk--set-conversion-start-marker (point))
   (nskk--insert-marker nskk-henkan-on-marker)
@@ -715,9 +749,11 @@ Actions:
   okuri-sokuon → `nskk--trigger-sokuon-okurigana'
   normal      → `nskk--process-normal-japanese-input'"
   (when nskk--sticky-shift-pending
-    (setq nskk--sticky-shift-pending nil)
-    (when (and (characterp char) (<= ?a char) (<= char ?z))
-      (setq char (upcase char))))
+    (let ((sticky-mode nskk--sticky-shift-pending))
+      (setq nskk--sticky-shift-pending nil)
+      (when (and (eq sticky-mode 'okurigana)
+                 (characterp char) (<= ?a char) (<= char ?z))
+        (setq char (upcase char)))))
   (let* ((char-type (cond
                         ((and (characterp char) (<= ?a char) (<= char ?z)) 'alphabetic-lower)
                         ((and (eq char ?+)

--- a/test/e2e/nskk-sticky-e2e-test.el
+++ b/test/e2e/nskk-sticky-e2e-test.el
@@ -34,28 +34,34 @@
 (require 'nskk-pbt-generators)
 (eval-when-compile (require 'cl-lib))
 
-;; In ddskk, sticky-shift mode allows typing ";" to act as a Shift key for
-;; the immediately following character.  This lets users enter uppercase
-;; letters (and thereby trigger preedit or okurigana) without holding Shift.
+;; Sticky-shift mode: pressing ";" immediately inserts the ▽ marker
+;; (entering preedit mode), matching ddskk's `skk-sticky-set-henkan-point'.
 ;;
 ;; Key rules:
-;;   ";"  followed by a consonant letter  → treated as the uppercase consonant
-;;                                          (e.g., ;k == K → starts ▽ preedit)
-;;   ";"  followed by a vowel letter      → treated as uppercase vowel
-;;                                          (e.g., ;a == A → uppercase okurigana trigger)
+;;   ";"  in idle Japanese mode           → immediately insert ▽ (preedit-pending)
+;;   ";"  in ▽ mode with kana             → arm okurigana (next char as boundary)
+;;   ";"  in ▽ mode without kana          → cancel preedit, insert literal ";"
 ;;   ";;" (double semicolon)              → cancel sticky shift, self-insert ";"
+;;   ";"  in converting (▼) mode          → fall through to self-insert
 
 ;;;;
 ;;;; Basic Sticky Shift Tests
 ;;;;
 
 (nskk-describe "sticky shift mode (スティッキーシフト)"
-  (nskk-it "semicolon followed by consonant starts preedit (▽)"
+  (nskk-it "semicolon immediately starts preedit (▽)"
     (nskk-e2e-with-buffer 'hiragana nil
-      ;; ";" acts as Shift; ";k" is equivalent to "K" → starts ▽ preedit.
+      ;; ";" immediately inserts ▽ marker.
+      (nskk-e2e-type ";")
+      ;; Preedit (▽) phase must be active after ";" alone.
+      (nskk-e2e-assert-henkan-phase 'on)))
+
+  (nskk-it "semicolon followed by consonant continues preedit input"
+    (nskk-e2e-with-buffer 'hiragana nil
+      ;; ";" inserts ▽ immediately; "k" is processed as normal preedit input.
       (nskk-e2e-type ";")
       (nskk-e2e-type "k")
-      ;; Preedit (▽) phase must be active after ;k.
+      ;; Preedit (▽) phase must remain active.
       (nskk-e2e-assert-henkan-phase 'on)))
 
   (nskk-it "double semicolon self-inserts a literal semicolon"
@@ -236,6 +242,82 @@
     (nskk-state-valid-mode-p (nskk-current-mode)))
   25)
 
+
+;;;;
+;;;; Immediate ▽ Behavior Tests
+;;;;
+
+(nskk-describe "immediate ▽ on sticky key"
+  (nskk-it "semicolon alone in hiragana inserts ▽ immediately"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-assert-mode 'hiragana)))
+
+  (nskk-it "semicolon alone in katakana inserts ▽ immediately"
+    (nskk-e2e-with-buffer 'katakana nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-assert-mode 'katakana)))
+
+  (nskk-it ";ka produces ▽か (normal lowercase in preedit)"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-type "ka")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-assert-buffer-matches "か")))
+
+  (nskk-it "semicolon in preedit-pending cancels preedit and inserts ;"
+    (nskk-e2e-with-buffer 'hiragana nil
+      ;; First ; enters ▽ (preedit-pending, no kana yet).
+      ;; The pending flag is 'immediate, so a second ; fires arm 1
+      ;; which cancels preedit + inserts literal ";".
+      (nskk-e2e-type ";")
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer ";"))))
+
+;;;;
+;;;; Okurigana via Sticky Key in Preedit
+;;;;
+
+(nskk-describe "sticky okurigana in preedit"
+  (nskk-it "semicolon in preedit-japanese arms okurigana"
+    (let ((dict '(("おおa" . ("大")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "Oo")         ; → ▽おお
+        (nskk-e2e-type ";")          ; arm okurigana
+        (nskk-e2e-type "a")          ; → okurigana A triggers conversion
+        (nskk-e2e-assert-henkan-phase 'active)))))
+
+;;;;
+;;;; Preedit-Pending via Uppercase + Sticky Key
+;;;;
+
+(nskk-describe "sticky key in preedit-pending (uppercase K then ;)"
+  (nskk-it "semicolon in preedit-pending (from uppercase) cancels preedit and inserts ;"
+    ;; Enter ▽ via uppercase K, then press ";" before typing any kana.
+    ;; Arm 4 fires: cancel-preedit + insert ";".
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "K")           ; → ▽ (preedit-pending via uppercase)
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-type ";")           ; arm 4: cancel + insert ";"
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer ";"))))
+
+;;;;
+;;;; Double-Semicolon from Okurigana State
+;;;;
+
+(nskk-describe "double-semicolon from okurigana state"
+  (nskk-it ";; after arming okurigana inserts ; without cancelling preedit"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "Ka")          ; → ▽か (preedit-japanese)
+      (nskk-e2e-type ";")           ; arm 3: set 'okurigana
+      (nskk-e2e-type ";")           ; arm 1: cancel okurigana + insert ";"
+      ;; Preedit should still be active (was-immediate is nil → no cancel-preedit)
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-assert-buffer-matches "か;"))))
 
 (provide 'nskk-sticky-e2e-test)
 

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -2104,7 +2104,7 @@
             (nskk--dcomp-prefix nil)
             (nskk--dcomp-index 0)
             (nskk--numeric-mode t)
-            (nskk--sticky-shift-pending t)
+            (nskk--sticky-shift-pending 'okurigana)
             (nskk--deferred-azik-state '(some state))
             (nskk--deferred-vowel-shadow-state t)
             (nskk--azik-colon-okuri-pending t)

--- a/test/unit/nskk-input-test.el
+++ b/test/unit/nskk-input-test.el
@@ -1603,21 +1603,22 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
     (should (fboundp 'nskk-handle-semicolon-key))
     (should (commandp 'nskk-handle-semicolon-key)))
 
-  (nskk-it "in standard mode + hiragana: first press sets sticky-shift-pending"
+  (nskk-it "in standard mode + hiragana: first press inserts ▽ and sets immediate"
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
         (nskk-set-mode-hiragana)
         (setq nskk--sticky-shift-pending nil)
         (nskk-handle-semicolon-key)
-        (should nskk--sticky-shift-pending))))
+        (should (eq nskk--sticky-shift-pending 'immediate))
+        (should (string-match-p nskk-henkan-on-marker (buffer-string))))))
 
   (nskk-it "in standard mode + hiragana: double-press cancels sticky and inserts ;"
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
         (nskk-set-mode-hiragana)
-        (setq nskk--sticky-shift-pending t)
+        (setq nskk--sticky-shift-pending 'immediate)
         (nskk-handle-semicolon-key)
         (should (null nskk--sticky-shift-pending))
         (should (string= (buffer-string) ";"))))))
@@ -1680,16 +1681,16 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
 ;;;
 
 (nskk-describe "nskk-process-japanese-input sticky-shift"
-  (nskk-it "sticky-shift converts lowercase to uppercase (triggers henkan start)"
-    ;; When nskk--sticky-shift-pending is t, the next lowercase letter is
-    ;; treated as uppercase, which triggers henkan start when auto-start is on.
+  (nskk-it "sticky-shift okurigana converts lowercase to uppercase (triggers henkan start)"
+    ;; When nskk--sticky-shift-pending is 'okurigana, the next lowercase letter
+    ;; is treated as uppercase, which triggers henkan start when auto-start is on.
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
-        (let ((nskk--sticky-shift-pending t)
+        (let ((nskk--sticky-shift-pending 'okurigana)
               (nskk-converter-auto-start-henkan t))
           (nskk-process-japanese-input ?k 1)
-          ;; ?k with sticky-shift → ?K → henkan start → ▽ marker in buffer
+          ;; ?k with sticky-shift okurigana → ?K → henkan start → ▽ marker in buffer
           (should (string-match-p nskk-henkan-on-marker (buffer-string)))))))
 
   (nskk-it "sticky-shift clears the pending flag after use"
@@ -1697,17 +1698,30 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
-        (let ((nskk--sticky-shift-pending t)
+        (let ((nskk--sticky-shift-pending 'okurigana)
               (nskk-converter-auto-start-henkan t))
           (nskk-process-japanese-input ?k 1)
           (should (null nskk--sticky-shift-pending))))))
 
-  (nskk-it "sticky-shift does not upcase non-letter chars"
+  (nskk-it "sticky-shift immediate does not upcase letters"
+    ;; When pending is 'immediate, lowercase letters are NOT upcased.
+    (nskk-prolog-test-with-isolated-db
+      (with-temp-buffer
+        (nskk-mode 1)
+        (let ((nskk--sticky-shift-pending 'immediate)
+              (nskk-converter-auto-start-henkan t))
+          (nskk-process-japanese-input ?k 1)
+          ;; Flag is consumed (set to nil)
+          (should (null nskk--sticky-shift-pending))
+          ;; No henkan marker was inserted ('immediate does not upcase)
+          (should-not (string-match-p nskk-henkan-on-marker (buffer-string)))))))
+
+  (nskk-it "sticky-shift okurigana does not upcase non-letter chars"
     ;; Digits are not in [a-z] so no upcase occurs; the flag is still consumed.
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
-        (let ((nskk--sticky-shift-pending t)
+        (let ((nskk--sticky-shift-pending 'okurigana)
               (nskk-converter-auto-start-henkan t))
           (nskk-process-japanese-input ?1 1)
           ;; Flag is consumed (set to nil)


### PR DESCRIPTION
## Summary

- **Immediate ▽ insertion**: pressing `;` in idle Japanese mode now immediately enters preedit-pending (▽) state, instead of deferring until the next character
- **6-arm dispatch**: rewrites `nskk--sticky-shift-dispatch` with priority-ordered arms for double-`;`, ▼ state, preedit-with-kana, preedit-pending, idle-Japanese, and non-Japanese
- **Symbol-valued flag**: `nskk--sticky-shift-pending` changes from boolean to discriminated symbol (`nil`/`immediate`/`okurigana`) so upcase guard and `;;` cancel behave correctly

## Key behavior

| Input | Context | Result |
|-------|---------|--------|
| `;` | idle Japanese | immediately insert ▽ |
| `;` | ▽ with kana | arm okurigana |
| `;` | ▽ without kana | cancel preedit, insert literal `;` |
| `;;` | any pending | cancel sticky shift, self-insert `;` |
| `;` | ▼ (converting) | fall through to self-insert |

## Test plan

- [x] All 5521 tests pass (unit + integration + e2e)
- [x] Zero byte-compile warnings
- [x] New E2E tests for immediate ▽, okurigana via sticky key, preedit-pending cancel, double-semicolon from okurigana state
- [x] Updated unit tests use symbol values (`'immediate`/`'okurigana`) instead of boolean
- [x] Manual verification via emacsclient -nw