### PR TITLE
fix: restore previous input mode after abbrev/numeric confirmation

### DIFF
--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -634,16 +634,21 @@ Does not reset the input mode."
   "Commit preedit text as-is without dictionary conversion (確定).
 Removes the henkan-on marker (▽), clears the conversion start marker,
 resets the romaji buffer, clears all five AZIK pending state variables
-(see `nskk--clear-azik-pending-state'), and clears the henkan phase."
-  (let ((start (nskk--get-conversion-start)))
+(see `nskk--clear-azik-pending-state'), and clears the henkan phase.
+When called in abbrev mode, restores the previous Japanese input mode
+via `nskk--restore-abbrev-mode'."
+  (let ((was-abbrev (nskk-with-current-state
+                      (eq (nskk-state-mode nskk-current-state) 'abbrev)))
+        (start (nskk--get-conversion-start)))
     (when start
-      (nskk--delete-marker-at start nskk-henkan-on-marker-regexp)))
-  (nskk--clear-conversion-start-marker)
-  (nskk--reset-romaji-buffer)
-  ;; Clear AZIK okurigana pending state that may have been armed in preedit.
-  (nskk--clear-azik-pending-state)
-  (nskk-with-current-state
-    (nskk-state-set-henkan-phase nskk-current-state nil)))
+      (nskk--delete-marker-at start nskk-henkan-on-marker-regexp))
+    (nskk--clear-conversion-start-marker)
+    (nskk--reset-romaji-buffer)
+    ;; Clear AZIK okurigana pending state that may have been armed in preedit.
+    (nskk--clear-azik-pending-state)
+    (nskk-with-current-state
+      (nskk-state-set-henkan-phase nskk-current-state nil))
+    (nskk--restore-abbrev-mode was-abbrev)))
 
 (defun nskk--replace-preedit-with-converted (text-start start converted)
   "Replace preedit at TEXT-START with CONVERTED text and remove ▽ marker at START."
@@ -857,12 +862,14 @@ Does nothing when not currently converting."
     (nskk-rollback-conversion)))
 
 (defun nskk--restore-abbrev-mode (was-abbrev)
-  "Restore previous Japanese mode when cancelling from abbrev preedit.
-WAS-ABBREV is non-nil when the active mode was abbrev at cancel time.
+  "Restore previous Japanese mode when exiting abbrev/numeric preedit.
+WAS-ABBREV is non-nil when the active mode was abbrev at exit time.
 Uses setf directly on the struct slot to avoid updating previous-mode
 \(this is a restore, not a user-initiated mode switch).
+Also clears `nskk--numeric-mode' since numeric mode reuses abbrev.
 No-op when WAS-ABBREV is nil or previous-mode is nil or abbrev."
   (when was-abbrev
+    (nskk-when-bound nskk--numeric-mode (setq nskk--numeric-mode nil))
     (let ((prev-mode (nskk-with-current-state
                        (nskk-state-previous-mode nskk-current-state))))
       (when (and prev-mode (not (eq prev-mode 'abbrev)))
@@ -1030,6 +1037,7 @@ in place and will immediately follow the inserted candidate."
            (index         (nskk-state-current-index nskk-current-state))
            (candidate     (nth index candidates))
            (start         (nskk--get-conversion-start))
+           (was-abbrev    (eq (nskk-state-mode nskk-current-state) 'abbrev))
            ;; NOTE: (overlayp obj) returns t even after delete-overlay — the
            ;; Lisp object persists but overlay-end returns nil for a deleted
            ;; overlay.  Always check overlay-end result, not just overlayp.
@@ -1084,6 +1092,8 @@ in place and will immediately follow the inserted candidate."
                       :registered-word nil))))
       ;; Clear all conversion state (includes candidate list dismissal).
       (nskk-henkan-do-reset)
+      ;; Restore abbrev mode if applicable.
+      (nskk--restore-abbrev-mode was-abbrev)
       (succeed candidate))))
 
 (defun nskk--select-candidate (direction)
@@ -1415,26 +1425,31 @@ ON-REGISTER is called (no args) after a word is successfully registered."
 Shared by all registration callbacks in the conversion pipeline.
 Optional READING is the original reading used for registration; when
 non-nil, an undo record is stored so `nskk-undo-kakutei' can revert
-and unregister the word."
-  (delete-region start (point))
-  (goto-char start)
-  (insert registered)
-  ;; Store undo record for registration undo.
-  (when reading
-    (let ((mode (nskk-with-current-state (nskk-state-mode nskk-current-state))))
-      (setq nskk--last-kakutei-record
-            (list :reading reading
-                  :candidates (list registered)
-                  :index 0
-                  :committed-text registered
-                  :buffer-start start
-                  :buffer-end (point)
-                  :mode (or mode 'hiragana)
-                  :registered-p t
-                  :registered-reading reading
-                  :registered-word registered))))
-  (nskk-henkan-do-reset)
-  (when (functionp on-done) (funcall on-done)))
+and unregister the word.
+When called in abbrev mode, restores the previous Japanese input mode
+via `nskk--restore-abbrev-mode'."
+  (let ((was-abbrev (nskk-with-current-state
+                      (eq (nskk-state-mode nskk-current-state) 'abbrev))))
+    (delete-region start (point))
+    (goto-char start)
+    (insert registered)
+    ;; Store undo record for registration undo.
+    (when reading
+      (let ((mode (nskk-with-current-state (nskk-state-mode nskk-current-state))))
+        (setq nskk--last-kakutei-record
+              (list :reading reading
+                    :candidates (list registered)
+                    :index 0
+                    :committed-text registered
+                    :buffer-start start
+                    :buffer-end (point)
+                    :mode (or mode 'hiragana)
+                    :registered-p t
+                    :registered-reading reading
+                    :registered-word registered))))
+    (nskk-henkan-do-reset)
+    (nskk--restore-abbrev-mode was-abbrev)
+    (when (functionp on-done) (funcall on-done))))
 
 (defun nskk--start-conversion-normal (start on-found on-not-found on-register)
   "Execute the normal (non-okurigana) conversion path.

--- a/test/e2e/nskk-abbrev-e2e-test.el
+++ b/test/e2e/nskk-abbrev-e2e-test.el
@@ -227,6 +227,7 @@
 (nskk-describe "abbrev mode conversion via RET"
   ;; / + "test" + SPC triggers dictionary conversion.
   ;; RET (commit-candidate) commits the first candidate without a newline.
+  ;; Mode should return to hiragana after commit.
   (nskk-it "commits first candidate with RET after SPC conversion"
     (let ((dict '(("test" . ("テスト" "Test")))))
       (nskk-e2e-with-buffer 'hiragana dict
@@ -236,7 +237,8 @@
         (nskk-e2e-assert-converting)
         (nskk-e2e-type "RET")
         (nskk-e2e-assert-not-converting)
-        (nskk-e2e-assert-buffer "テスト"))))
+        (nskk-e2e-assert-buffer "テスト")
+        (nskk-e2e-assert-mode 'hiragana))))
 
   (nskk-it "cycles to second candidate with SPC then commits with C-j"
     (let ((dict '(("test" . ("テスト" "Test")))))
@@ -249,7 +251,8 @@
         (nskk-e2e-assert-converting)
         (nskk-e2e-type "C-j")
         (nskk-e2e-assert-not-converting)
-        (nskk-e2e-assert-buffer "Test")))))
+        (nskk-e2e-assert-buffer "Test")
+        (nskk-e2e-assert-mode 'hiragana)))))
 
 ;;;; 8. C-g during abbrev conversion cancels back to preedit
 
@@ -265,6 +268,56 @@
         (nskk-e2e-assert-converting)
         (nskk-e2e-type "C-g")
         (nskk-e2e-assert-not-converting)))))
+
+;;;; 9. Abbrev mode restores previous mode after confirmation
+
+(nskk-describe "abbrev mode restores previous mode after confirmation"
+  (nskk-it "C-j preedit commit restores hiragana"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "/")
+      (nskk-e2e-assert-mode 'abbrev)
+      (nskk-e2e-type "test")
+      (nskk-e2e-assert-buffer "▽test")
+      (nskk-e2e-type "C-j")
+      (nskk-e2e-assert-buffer "test")
+      (nskk-e2e-assert-mode 'hiragana)))
+
+  (nskk-it "C-j preedit commit restores katakana"
+    (nskk-e2e-with-buffer 'katakana nil
+      (nskk-e2e-type "/")
+      (nskk-e2e-assert-mode 'abbrev)
+      (nskk-e2e-type "abc")
+      (nskk-e2e-type "C-j")
+      (nskk-e2e-assert-buffer "abc")
+      (nskk-e2e-assert-mode 'katakana)))
+
+  (nskk-it "SPC candidate commit with RET restores hiragana"
+    (let ((dict '(("test" . ("テスト")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "/")
+        (nskk-e2e-type "test")
+        (nskk-e2e-type "SPC")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "RET")
+        (nskk-e2e-assert-mode 'hiragana))))
+
+  (nskk-it "SPC candidate commit with C-j restores hiragana"
+    (let ((dict '(("test" . ("テスト")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "/")
+        (nskk-e2e-type "test")
+        (nskk-e2e-type "SPC")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "C-j")
+        (nskk-e2e-assert-mode 'hiragana))))
+
+  (nskk-it "C-g cancel still restores hiragana"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "/")
+      (nskk-e2e-assert-mode 'abbrev)
+      (nskk-e2e-type "test")
+      (nskk-e2e-type "C-g")
+      (nskk-e2e-assert-mode 'hiragana))))
 
 ;;;;
 ;;;; Property-Based Tests

--- a/test/e2e/nskk-registration-e2e-test.el
+++ b/test/e2e/nskk-registration-e2e-test.el
@@ -313,6 +313,8 @@
         ;; SPC: no candidates for "test" in empty dict → registration → "テスト"
         (nskk-e2e-type "SPC")
         (nskk-e2e-assert-buffer "テスト" "Registered word should be inserted after abbrev registration")
+        ;; Mode should be restored to hiragana after abbrev registration.
+        (nskk-e2e-assert-mode 'hiragana)
         ;; Verify the word is now stored in the user dict under the abbrev key.
         (should (nskk-prolog-query-one '(user-dict-entry "test" \?_))))))
 

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -2596,6 +2596,87 @@
         (should (= nskk--henkan-count 0))))))
 
 ;;;
+;;; nskk--restore-abbrev-mode
+;;;
+
+(nskk-describe "nskk--restore-abbrev-mode"
+  (nskk-it "restores previous-mode when was-abbrev is t"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'abbrev)))
+        (setf (nskk-state-previous-mode nskk-current-state) 'hiragana)
+        (nskk--restore-abbrev-mode t)
+        (should (eq (nskk-state-mode nskk-current-state) 'hiragana)))))
+
+  (nskk-it "no-op when was-abbrev is nil"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana)))
+        (nskk--restore-abbrev-mode nil)
+        (should (eq (nskk-state-mode nskk-current-state) 'hiragana)))))
+
+  (nskk-it "no-op when previous-mode is abbrev"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'abbrev)))
+        (setf (nskk-state-previous-mode nskk-current-state) 'abbrev)
+        (nskk--restore-abbrev-mode t)
+        (should (eq (nskk-state-mode nskk-current-state) 'abbrev)))))
+
+  (nskk-it "clears nskk--numeric-mode when was-abbrev is t"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'abbrev))
+            (nskk--numeric-mode t))
+        (setf (nskk-state-previous-mode nskk-current-state) 'hiragana)
+        (nskk--restore-abbrev-mode t)
+        (should-not nskk--numeric-mode))))
+
+  (nskk-it "does not clear nskk--numeric-mode when was-abbrev is nil"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (nskk--numeric-mode t))
+        (nskk--restore-abbrev-mode nil)
+        (should nskk--numeric-mode))))
+
+  (nskk-it "no-op when previous-mode is nil"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'abbrev)))
+        (setf (nskk-state-previous-mode nskk-current-state) nil)
+        (nskk--restore-abbrev-mode t)
+        (should (eq (nskk-state-mode nskk-current-state) 'abbrev))))))
+
+;;;
+;;; nskk-henkan-kakutei abbrev mode restore
+;;;
+
+(nskk-describe "nskk-henkan-kakutei abbrev mode restore"
+  (nskk-it "restores previous mode after preedit commit from abbrev"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'abbrev))
+            (nskk--conversion-start-marker (make-marker))
+            (nskk--pending-romaji-overlay nil)
+            (nskk--romaji-buffer "")
+            (nskk--henkan-count 0))
+        (setf (nskk-state-previous-mode nskk-current-state) 'hiragana)
+        (insert nskk-henkan-on-marker "test")
+        (set-marker nskk--conversion-start-marker (point-min))
+        (goto-char (point-max))
+        (nskk-state-set-henkan-phase nskk-current-state 'on)
+        (nskk-henkan-kakutei)
+        (should (eq (nskk-state-mode nskk-current-state) 'hiragana)))))
+
+  (nskk-it "does not change mode after preedit commit from hiragana"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (nskk--conversion-start-marker (make-marker))
+            (nskk--pending-romaji-overlay nil)
+            (nskk--romaji-buffer "")
+            (nskk--henkan-count 0))
+        (insert nskk-henkan-on-marker "かんじ")
+        (set-marker nskk--conversion-start-marker (point-min))
+        (goto-char (point-max))
+        (nskk-state-set-henkan-phase nskk-current-state 'on)
+        (nskk-henkan-kakutei)
+        (should (eq (nskk-state-mode nskk-current-state) 'hiragana))))))
+
+;;;
 ;;; nskk--flush-romaji-before-okuri
 ;;;
 


### PR DESCRIPTION
## Summary

- After confirming text in abbrev mode (C-j, RET, or typing to commit), the input mode stayed in abbrev instead of returning to the previous Japanese mode (e.g. hiragana)
- Root cause: `nskk--restore-abbrev-mode` existed but was only called from the cancel path (C-g), not from any of the three confirmation paths
- Added `nskk--restore-abbrev-mode` calls to `nskk-henkan-kakutei`, `nskk-commit-current`, and `nskk--insert-registered-and-reset`
- Enhanced `nskk--restore-abbrev-mode` to also clear `nskk--numeric-mode` (since numeric mode reuses abbrev internally)

## Changed files

- `nskk-henkan.el` — production fix (3 confirmation paths + enhanced restore function)
- `test/unit/nskk-henkan-test.el` — 8 new unit tests for restore logic
- `test/e2e/nskk-abbrev-e2e-test.el` — 5 new E2E tests + 2 existing tests strengthened with mode assertions
- `test/e2e/nskk-registration-e2e-test.el` — mode assertion added to registration-from-abbrev test

## Test plan

- [x] All unit tests pass (`nskk--restore-abbrev-mode`, `nskk-henkan-kakutei`)
- [x] All E2E abbrev tests pass (C-j, RET, SPC+C-j, SPC+RET, C-g restore)
- [x] Registration E2E test confirms mode restore after abbrev registration
- [x] Manual verification via emacs daemon