### PR TITLE
fix: TAB pass-through delegates to major-mode binding

### DIFF
--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -112,6 +112,7 @@
 (declare-function nskk-process-japanese-input "nskk-input")
 (declare-function nskk-set-mode-numeric "nskk-input")
 (declare-function nskk--try-candidate-selection/k "nskk-input" (char on-found on-not-found))
+(defvar nskk-mode)                    ;; Forward declaration from nskk.el
 (defvar nskk-converter-romaji-style)
 (defvar nskk--romaji-buffer)          ;; Forward declaration from nskk-state.el
 ;; AZIK deferred state variables from nskk-input.el
@@ -792,11 +793,17 @@ beginning-of-buffer errors so DEL on an empty buffer is a no-op."
 In preedit mode, behavior depends on `nskk-dcomp-style':
   capf  -- triggers `completion-at-point' (works with corfu/company).
   cycle -- traditional inline cycling via `nskk-dynamic-complete'.
-In other modes, delegates to `indent-for-tab-command'."
+In other modes, delegates to the underlying major-mode TAB binding
+\(e.g. `org-cycle' in Org mode).  Falls back to `indent-for-tab-command'
+when no major-mode binding exists."
   ('dynamic-complete (if (eq nskk-dcomp-style 'capf)
                          (completion-at-point)
                        (nskk-dynamic-complete)))
-  (_ (indent-for-tab-command)))
+  (_ (let ((cmd (let ((nskk-mode nil))
+                  (key-binding "\t"))))
+       (if (commandp cmd)
+           (call-interactively cmd)
+         (indent-for-tab-command)))))
 
 (nskk-define-mode-switch-handler hash
   "Handle # key: enter numeric input mode in Japanese mode.

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -1263,25 +1263,40 @@ and configures state."
           (nskk-when (nskk-handle-tab))
           (nskk-then (should complete-called))))))
 
-  (nskk-it "calls indent-for-tab-command when not in preedit"
+  (nskk-it "delegates to major-mode TAB binding when not in preedit"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (major-mode-called nil))
+        (let ((test-map (make-sparse-keymap)))
+          (define-key test-map "\t"
+            (lambda () (interactive) (setq major-mode-called t)))
+          (use-local-map test-map)
+          (nskk-when (nskk-handle-tab))
+          (nskk-then (should major-mode-called))))))
+
+  (nskk-it "falls back to indent-for-tab-command when no major-mode TAB binding"
     (with-temp-buffer
       (let ((nskk-current-state (nskk-state-create 'hiragana))
             (indent-called nil))
+        (use-local-map (make-sparse-keymap))
         (nskk-with-mocks ((indent-for-tab-command (lambda (&rest _) (interactive) (setq indent-called t))))
           (nskk-when (nskk-handle-tab))
           (nskk-then (should indent-called))))))
 
-  (nskk-it "calls indent-for-tab-command when converting (pass-through rule)"
+  (nskk-it "delegates to major-mode TAB binding when converting (pass-through rule)"
     (with-temp-buffer
       (let ((nskk-current-state (nskk-state-create 'hiragana))
-            (indent-called nil))
+            (major-mode-called nil))
         (nskk--set-conversion-start-marker (point-min))
         (insert "preedit")
         (nskk-state-set-candidates nskk-current-state '("result"))
         (nskk-state-force-henkan-phase nskk-current-state 'active)
-        (nskk-with-mocks ((indent-for-tab-command (lambda (&rest _) (interactive) (setq indent-called t))))
+        (let ((test-map (make-sparse-keymap)))
+          (define-key test-map "\t"
+            (lambda () (interactive) (setq major-mode-called t)))
+          (use-local-map test-map)
           (nskk-when (nskk-handle-tab))
-          (nskk-then (should indent-called)))))))
+          (nskk-then (should major-mode-called)))))))
 
 ;;;
 ;;; nskk-handle-hash behavior


### PR DESCRIPTION
## Summary
- nskk-handle-tab in normal state now delegates to the underlying major-mode TAB binding (e.g. `org-cycle` in org-mode) instead of hardcoding `indent-for-tab-command`
- Uses `(let ((nskk-mode nil)) (key-binding "\t"))` to bypass the minor-mode keymap and discover the original binding
- Falls back to `indent-for-tab-command` when no major-mode binding exists

## Test plan
- [x] Unit tests: major-mode delegation, fallback to indent-for-tab-command, converting pass-through (3 tests replacing 2)
- [x] Full suite: 5535/5535 pass
- [x] Byte-compile: zero warnings
- [x] Manual verification: emacs daemon + org-mode buffer, TAB folds/unfolds subtrees with nskk-mode active