### PR TITLE
fix: BS in normal hiragana mode deletes pending romaji before committed text

### DIFF
--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -727,6 +727,47 @@ Otherwise clears any residual AZIK deferred state and calls
   ('cancel-preedit (nskk-cancel-preedit))
   (_ (nskk--clear-azik-pending-state) (keyboard-quit)))
 
+(defun nskk--backspace-retract-pending ()
+  "Retract one pending input state if any is active.
+Checks AZIK deferred state and romaji buffer in priority order:
+DA > DV > CP > CD > romaji-buffer.
+SP is excluded: it has no visible buffer artifact to retract.
+Returns non-nil if backspace was consumed (caller must not delete further).
+Caller is responsible for preedit boundary checks after retraction."
+  (cond
+   ;; 1. DA: deferred-azik-state -- delete tentative kana
+   ((and (boundp 'nskk--deferred-azik-state) nskk--deferred-azik-state)
+    (delete-char (- (length (cdr nskk--deferred-azik-state))))
+    (setq nskk--deferred-azik-state nil)
+    t)
+   ;; 2. DV: deferred-vowel-shadow-state -- delete tentative kana
+   ((and (boundp 'nskk--deferred-vowel-shadow-state)
+         nskk--deferred-vowel-shadow-state)
+    (delete-char (- (length (cdr nskk--deferred-vowel-shadow-state))))
+    (setq nskk--deferred-vowel-shadow-state nil)
+    t)
+   ;; 3. CP: colon-okuri-pending -- delete `*' marker
+   ((and (boundp 'nskk--azik-colon-okuri-pending)
+         nskk--azik-colon-okuri-pending)
+    (delete-char -1)
+    (setq nskk--azik-colon-okuri-pending nil)
+    t)
+   ;; 4. CD: colon-okuri-deferred -- delete placeholder, reset romaji
+   ((and (boundp 'nskk--azik-colon-okuri-deferred)
+         nskk--azik-colon-okuri-deferred)
+    (delete-char (- (length (cdr nskk--azik-colon-okuri-deferred))))
+    (setq nskk--azik-colon-okuri-deferred nil)
+    (nskk--reset-romaji-buffer)
+    t)
+   ;; 5. Non-empty romaji buffer -- delete last char, update overlay
+   ((and (boundp 'nskk--romaji-buffer)
+         (not (string-empty-p nskk--romaji-buffer)))
+    (setq nskk--romaji-buffer (substring nskk--romaji-buffer 0 -1))
+    (if (string-empty-p nskk--romaji-buffer)
+        (nskk--clear-pending-romaji)
+      (nskk--show-pending-romaji nskk--romaji-buffer))
+    t)))
+
 (defun nskk--backspace-in-preedit ()
   "Delete pending romaji, AZIK deferred state, or last preedit char.
 Called when backspace is pressed in preedit state.
@@ -736,38 +777,9 @@ If point drifted left of preedit boundary, clamp it instead."
          (preedit-min (and start (+ start (length nskk-henkan-on-marker)))))
     (when preedit-min
       (cond
-       ;; 1. DA: deferred-azik-state -- delete tentative kana
-       ((and (boundp 'nskk--deferred-azik-state) nskk--deferred-azik-state)
-        (delete-char (- (length (cdr nskk--deferred-azik-state))))
-        (setq nskk--deferred-azik-state nil)
+       ((nskk--backspace-retract-pending)
         (when (<= (point) preedit-min) (nskk-cancel-preedit)))
-       ;; 2. DV: deferred-vowel-shadow-state -- delete tentative kana
-       ((and (boundp 'nskk--deferred-vowel-shadow-state)
-             nskk--deferred-vowel-shadow-state)
-        (delete-char (- (length (cdr nskk--deferred-vowel-shadow-state))))
-        (setq nskk--deferred-vowel-shadow-state nil)
-        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
-       ;; 3. CP: colon-okuri-pending -- delete `*' marker
-       ((and (boundp 'nskk--azik-colon-okuri-pending)
-             nskk--azik-colon-okuri-pending)
-        (delete-char -1)
-        (setq nskk--azik-colon-okuri-pending nil)
-        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
-       ;; 4. CD: colon-okuri-deferred -- delete placeholder, reset romaji
-       ((and (boundp 'nskk--azik-colon-okuri-deferred)
-             nskk--azik-colon-okuri-deferred)
-        (delete-char (- (length (cdr nskk--azik-colon-okuri-deferred))))
-        (setq nskk--azik-colon-okuri-deferred nil)
-        (nskk--reset-romaji-buffer)
-        (when (<= (point) preedit-min) (nskk-cancel-preedit)))
-       ;; 5. Non-empty romaji buffer -- delete last char, update overlay
-       ((and (boundp 'nskk--romaji-buffer)
-             (not (string-empty-p nskk--romaji-buffer)))
-        (setq nskk--romaji-buffer (substring nskk--romaji-buffer 0 -1))
-        (if (string-empty-p nskk--romaji-buffer)
-            (nskk--clear-pending-romaji)
-          (nskk--show-pending-romaji nskk--romaji-buffer)))
-       ;; 6. Existing logic -- delete committed kana or cancel
+       ;; Existing logic -- delete committed kana or cancel
        ((> (point) preedit-min)
         (delete-char -1))
        ((= (point) preedit-min)
@@ -786,7 +798,8 @@ Otherwise delegates to `delete-char', silently ignoring
 beginning-of-buffer errors so DEL on an empty buffer is a no-op."
   ('delete-preedit-char (nskk--backspace-in-preedit))
   ('rollback-to-reading (nskk-rollback-conversion))
-  (_ (ignore-errors (delete-char -1))))
+  (_ (unless (nskk--backspace-retract-pending)
+       (ignore-errors (delete-char -1)))))
 
 (nskk-define-key-handler tab
   "Handle TAB key: dynamic completion in preedit, otherwise pass through.

--- a/test/e2e/nskk-kana-input-e2e-test.el
+++ b/test/e2e/nskk-kana-input-e2e-test.el
@@ -497,6 +497,69 @@
       (nskk-e2e-assert-buffer "ー"
                               "romaji \"-\" → \"ー\" failed in katakana mode"))))
 
+;;;;
+;;;; BS (DEL) with pending romaji in normal hiragana mode
+;;;;
+
+(nskk-describe "BS clears pending romaji in normal hiragana mode"
+  (nskk-it "clears single pending romaji consonant"
+    ;; Type "k" → romaji buffer has "k", overlay shows "k", no buffer text.
+    ;; BS should clear "k" from romaji buffer and overlay, not delete buffer text.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "k")
+      (should (equal nskk--romaji-buffer "k"))
+      (nskk-e2e-type "DEL")
+      (should (equal nskk--romaji-buffer ""))
+      (nskk-e2e-assert-buffer "" "DEL with pending romaji: must clear romaji, not delete text")))
+
+  (nskk-it "clears pending romaji without deleting committed kana"
+    ;; Type "ka" (→ か), then "g" (pending romaji).
+    ;; BS should clear "g", leaving か intact.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "ka")
+      (nskk-e2e-assert-buffer "か")
+      (nskk-e2e-type "g")
+      (should (equal nskk--romaji-buffer "g"))
+      (nskk-e2e-type "DEL")
+      (should (equal nskk--romaji-buffer ""))
+      (nskk-e2e-assert-buffer "か" "DEL must clear pending 'g', not delete committed か")))
+
+  (nskk-it "truncates multi-char romaji then clears on second BS"
+    ;; Type "ka" (→ か), then "sh" (two-char pending romaji).
+    ;; First BS: "sh" → "s".  Second BS: "s" → "" (cleared).
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "ka")
+      (nskk-e2e-type "s")
+      (should (equal nskk--romaji-buffer "s"))
+      (nskk-e2e-type "h")
+      (should (equal nskk--romaji-buffer "sh"))
+      (nskk-e2e-type "DEL")
+      (should (equal nskk--romaji-buffer "s"))
+      (nskk-e2e-assert-buffer "か" "1st DEL: truncate 'sh' to 's', か remains")
+      (nskk-e2e-type "DEL")
+      (should (equal nskk--romaji-buffer ""))
+      (nskk-e2e-assert-buffer "か" "2nd DEL: clear 's', か still remains")))
+
+  (nskk-it "falls through to delete committed text when no pending state"
+    ;; Type "ka" (→ か), no pending romaji.  BS deletes か.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "ka")
+      (should (equal nskk--romaji-buffer ""))
+      (nskk-e2e-type "DEL")
+      (nskk-e2e-assert-buffer "" "DEL with no pending state: delete committed か")))
+
+  (nskk-it "clears pending romaji then next BS deletes committed text"
+    ;; Type "ka" (→ か), "k" (pending). First BS clears "k", second BS deletes か.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type "ka")
+      (nskk-e2e-type "k")
+      (should (equal nskk--romaji-buffer "k"))
+      (nskk-e2e-type "DEL")
+      (should (equal nskk--romaji-buffer ""))
+      (nskk-e2e-assert-buffer "か" "1st DEL: clear pending 'k'")
+      (nskk-e2e-type "DEL")
+      (nskk-e2e-assert-buffer "" "2nd DEL: delete committed か"))))
+
 (provide 'nskk-kana-input-e2e-test)
 
 ;;; nskk-kana-input-e2e-test.el ends here

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -1022,6 +1022,61 @@ and configures state."
          (should (= (point) 3)))))))
 
 ;;;
+;;; nskk--backspace-retract-pending
+;;;
+
+(nskk-describe "nskk--backspace-retract-pending"
+  (nskk-it "is defined as a callable function (fboundp)"
+    (should (fboundp 'nskk--backspace-retract-pending)))
+
+  (nskk-it "returns non-nil and clears single-char romaji buffer"
+    (let ((clear-called nil))
+      (nskk-with-mocks ((nskk--clear-pending-romaji (lambda () (setq clear-called t))))
+        (with-temp-buffer
+          (let ((nskk--romaji-buffer "k"))
+            (should (nskk--backspace-retract-pending))
+            (should (equal nskk--romaji-buffer ""))
+            (should clear-called))))))
+
+  (nskk-it "returns non-nil and truncates multi-char romaji buffer"
+    (let ((show-arg nil))
+      (nskk-with-mocks ((nskk--show-pending-romaji (lambda (s) (setq show-arg s))))
+        (with-temp-buffer
+          (let ((nskk--romaji-buffer "sh"))
+            (should (nskk--backspace-retract-pending))
+            (should (equal nskk--romaji-buffer "s"))
+            (should (equal show-arg "s")))))))
+
+  (nskk-it "returns nil when all pending state is empty"
+    (with-temp-buffer
+      (let ((nskk--romaji-buffer "")
+            (nskk--deferred-azik-state nil)
+            (nskk--deferred-vowel-shadow-state nil)
+            (nskk--azik-colon-okuri-pending nil)
+            (nskk--azik-colon-okuri-deferred nil))
+        (should-not (nskk--backspace-retract-pending)))))
+
+  (nskk-it "returns non-nil and clears DA (deferred-azik-state)"
+    (with-temp-buffer
+      (let ((nskk--romaji-buffer "")
+            (nskk--deferred-azik-state (cons ?k "きん")))
+        (insert "きん")
+        (goto-char (point-max))
+        (should (nskk--backspace-retract-pending))
+        (should-not nskk--deferred-azik-state)
+        (should (equal (buffer-string) "")))))
+
+  (nskk-it "returns non-nil and clears DV (deferred-vowel-shadow-state)"
+    (with-temp-buffer
+      (let ((nskk--romaji-buffer "")
+            (nskk--deferred-vowel-shadow-state (cons "sh" "すう")))
+        (insert "すう")
+        (goto-char (point-max))
+        (should (nskk--backspace-retract-pending))
+        (should-not nskk--deferred-vowel-shadow-state)
+        (should (equal (buffer-string) ""))))))
+
+;;;
 ;;; nskk--backspace-in-preedit
 ;;;
 


### PR DESCRIPTION
## Summary
- BS in normal hiragana mode now clears pending romaji before deleting committed kana
- Extracted `nskk--backspace-retract-pending` shared helper from `nskk--backspace-in-preedit` (5-step priority: DA > DV > CP > CD > romaji-buffer)
- Both preedit and normal-mode BS handlers now call the shared helper, eliminating duplication

## Bug
When typing `か` then `g` (pending romaji) in normal hiragana mode, pressing BS deleted `か` instead of clearing the pending `g`. The fix for ▽ preedit mode (PR #13) was not applied to normal mode.

## Test plan
- [x] 6 new unit tests for `nskk--backspace-retract-pending` (romaji clear/truncate, DA/DV clear, nil return)
- [x] 5 new e2e tests for BS in normal hiragana mode (single consonant, committed+pending, multi-char, fallthrough, chained BS)
- [x] All 5546 tests pass (0 failures)
- [x] Manual verification via emacsclient (4 scenarios)