### PR TITLE
fix: sticky-shift self-insert in ascii mode and okurigana implicit kakutei

### DIFF
--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -182,6 +182,7 @@ or `nskk-with-conversion-context')."
      (nskk-state-set-candidates nskk-current-state nil)
      (nskk-state-set-okurigana nskk-current-state nil)
      (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress nil)
+     (nskk-state-put-metadata nskk-current-state 'okuri-continuation-kana-emitted nil)
      (nskk-state-set-henkan-phase nskk-current-state nil)))
 
 ;; Forward declarations for variables defined in the "Candidate Display Hooks"

--- a/nskk-input.el
+++ b/nskk-input.el
@@ -435,6 +435,7 @@ In standard mode + non-Japanese mode: self-insert (on-not-found path).
       ('sticky-shift
        (if (nskk--sticky-shift-dispatch)
            (succeed t)
+         (nskk-self-insert 1)
          (fail)))
       ('self-insert
        (nskk-self-insert 1)
@@ -445,15 +446,32 @@ In standard mode + non-Japanese mode: self-insert (on-not-found path).
 
 (defun nskk--okurigana-continuation-p (char)
   "Return non-nil when CHAR should continue okurigana kana in ▼ state.
-During okurigana conversion, lowercase ASCII letters extend the okurigana
-suffix (e.g., `ru' in KaEru → 変える, `a' in KaTTa → 勝った).
-Uppercase letters start a new word and trigger implicit kakutei instead.
-Non-alphabetic characters (digits, symbols) are not romaji and also
-trigger implicit kakutei."
+During okurigana conversion, lowercase ASCII letters may extend the
+okurigana suffix when completing an in-progress romaji sequence (e.g.,
+`u' after `r' in KaEru → 変える).  Once a continuation kana has been
+fully emitted, all subsequent lowercase letters trigger implicit kakutei.
+When no romaji is pending and CHAR alone forms a complete kana (vowels),
+implicit kakutei is triggered immediately.  When CHAR alone is an
+incomplete romaji prefix (consonants), it enters the romaji buffer as
+okurigana continuation."
   (and (nskk-state-get-metadata nskk-current-state 'okurigana-in-progress)
        (characterp char)
        (<= ?a char)
-       (<= char ?z)))
+       (<= char ?z)
+       ;; Four-level guard:
+       ;; 0. AZIK deferred correction pending + vowel → always continue
+       ;;    (deferred correction will modify romaji buffer inside kana pipeline)
+       ;; 1. Romaji buffer non-empty → always continue (completing sequence)
+       ;; 2. Continuation kana already emitted → kakutei (nil)
+       ;; 3. Empty romaji: vowel (complete kana) → kakutei, consonant → continue
+       (cond
+        ((and (or (bound-and-true-p nskk--deferred-azik-state)
+                  (bound-and-true-p nskk--deferred-vowel-shadow-state))
+              (nskk-prolog-holds-p `(vowel-char ,char)))
+         t)
+        ((not (string-empty-p nskk--romaji-buffer)) t)
+        ((nskk-state-get-metadata nskk-current-state 'okuri-continuation-kana-emitted) nil)
+        (t (eq :incomplete (nskk-converter-lookup (char-to-string char)))))))
 
 (defun nskk--implicit-kakutei-needed-p ()
   "Return non-nil when implicit kakutei should fire.
@@ -577,10 +595,15 @@ arguments after all insertions and side effects complete."
           (nskk--trigger-okuri-conversion okuri preedit-end)
           (nskk-state-set-okurigana nskk-current-state nil))
       (dotimes (_ n) (insert converted))
-      (when nskk--azik-sokuon-okuri-kana-pending
+      (cond
+       (nskk--azik-sokuon-okuri-kana-pending
         (setq nskk--azik-sokuon-okuri-kana-pending nil)
         (nskk-with-current-state
-          (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress nil))))))
+          (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress nil)))
+       ((nskk-with-current-state
+          (nskk-state-get-metadata nskk-current-state 'okurigana-in-progress))
+        (nskk-with-current-state
+          (nskk-state-put-metadata nskk-current-state 'okuri-continuation-kana-emitted t)))))))
 
 (defun nskk--convert-kana-for-mode (kana)
   "Convert hiragana KANA to the script appropriate for the current input mode.

--- a/test/e2e/nskk-okurigana-e2e-test.el
+++ b/test/e2e/nskk-okurigana-e2e-test.el
@@ -311,17 +311,15 @@
         (nskk-e2e-type "C-j")
         (nskk-e2e-assert-buffer "良い天気"))))
 
-  (nskk-it "lowercase after okurigana ▼ continues as okurigana extension"
-    ;; After YoI → ▼良い, lowercase 'a' is okurigana continuation (romaji),
-    ;; NOT implicit kakutei.  The あ is appended after い in ▼ state.
+  (nskk-it "vowel after okurigana ▼ triggers implicit kakutei"
+    ;; After YoI → ▼良い, lowercase 'a' (vowel = complete kana) triggers
+    ;; implicit kakutei: commit 良い, then process 'a' as new input → あ.
     (let ((dict '(("よi" . ("良")))))
       (nskk-e2e-with-buffer 'hiragana dict
         (nskk-e2e-type "YoI")
         (nskk-e2e-assert-converting)
         (nskk-e2e-type "a")
-        ;; Still in ▼ (okurigana continuation)
-        (nskk-e2e-assert-converting)
-        (nskk-e2e-type "C-j")
+        (nskk-e2e-assert-not-converting)
         (nskk-e2e-assert-buffer "良いあ"))))
 
   (nskk-it "digit after okurigana ▼ triggers implicit kakutei"
@@ -360,6 +358,59 @@
         (nskk-e2e-assert-converting)
         (nskk-e2e-type "C-j")
         (nskk-e2e-assert-buffer "書く愛い")))))
+
+;;;; Okurigana Implicit Kakutei Tests
+;;
+;; After okurigana conversion (▼ state with okurigana-in-progress):
+;;   - Vowels (complete single-char kana) trigger implicit kakutei
+;;   - Consonants (incomplete romaji) continue as okurigana extension
+;;   - After continuation kana emitted, ALL lowercase triggers kakutei
+
+(nskk-describe "okurigana implicit kakutei"
+  (nskk-it "consonant after okurigana ▼ continues as okurigana"
+    ;; After OKuRi → ▼送り, consonant 'k' is incomplete romaji →
+    ;; enters romaji buffer as okurigana continuation (not kakutei).
+    (let ((dict '(("おくr" . ("送")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "OKuRi")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "k")
+        (nskk-e2e-assert-converting))))
+
+  (nskk-it "after continuation kana emitted, any lowercase triggers kakutei"
+    ;; After OKuRi → ▼送り, type 'ku' → emits く (continuation kana).
+    ;; Then 'a' triggers implicit kakutei regardless of vowel/consonant.
+    (let ((dict '(("おくr" . ("送")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "OKuRi")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "ku")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "a")
+        (nskk-e2e-assert-not-converting)
+        (nskk-e2e-assert-buffer "送りくあ"))))
+
+  (nskk-it "multi-char okurigana KaEru preserved"
+    ;; KaE → ▼変え, 'r' is consonant → continuation, 'u' → る emitted.
+    ;; Next lowercase 'a' triggers implicit kakutei.
+    (let ((dict '(("かe" . ("変")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "KaEru")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "a")
+        (nskk-e2e-assert-not-converting)
+        (nskk-e2e-assert-buffer "変えるあ"))))
+
+  (nskk-it "consonant after continuation kana also triggers kakutei"
+    ;; After continuation kana emitted, even consonants trigger kakutei.
+    (let ((dict '(("おくr" . ("送")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type "OKuRi")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "ku")
+        (nskk-e2e-assert-converting)
+        (nskk-e2e-type "k")
+        (nskk-e2e-assert-not-converting)))))
 
 ;;;; Regression Tests: Pending Romaji Discard on Okurigana Trigger
 ;;

--- a/test/e2e/nskk-sticky-e2e-test.el
+++ b/test/e2e/nskk-sticky-e2e-test.el
@@ -319,6 +319,28 @@
       (nskk-e2e-assert-henkan-phase 'on)
       (nskk-e2e-assert-buffer-matches "か;"))))
 
+;;;;
+;;;; Sticky Shift in Direct Input Mode
+;;;;
+
+;; Bug fix: semicolon in direct input (ascii) mode was consumed by the
+;; sticky-shift handler without inserting a literal character.
+;; The (fail) CPS path invoked #'ignore, silently eating the keypress.
+
+(nskk-describe "sticky shift in direct input mode"
+  (nskk-it "semicolon in ascii mode inserts literal semicolon"
+    (nskk-e2e-with-buffer nil nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-buffer ";")))
+
+  (nskk-it "semicolon in ascii mode does not arm sticky shift"
+    (nskk-e2e-with-buffer nil nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-type "k")
+      ;; Both characters should be inserted literally, no preedit.
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer ";k"))))
+
 (provide 'nskk-sticky-e2e-test)
 
 ;;; nskk-sticky-e2e-test.el ends here

--- a/test/unit/nskk-input-test.el
+++ b/test/unit/nskk-input-test.el
@@ -1481,14 +1481,45 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
 ;;;
 
 (nskk-describe "nskk--okurigana-continuation-p"
-  (nskk-it "returns non-nil for lowercase a-z when okurigana-in-progress is set"
+  (nskk-it "returns non-nil for consonants (incomplete romaji) when okurigana-in-progress is set"
     (nskk-prolog-test-with-isolated-db
       (with-temp-buffer
         (nskk-mode 1)
         (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress t)
+        (should (nskk--okurigana-continuation-p ?k))
+        (should (nskk--okurigana-continuation-p ?s))
+        (should (nskk--okurigana-continuation-p ?t)))))
+
+  (nskk-it "returns nil for vowels (complete kana) when okurigana-in-progress is set"
+    (nskk-prolog-test-with-isolated-db
+      (with-temp-buffer
+        (nskk-mode 1)
+        (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress t)
+        (should-not (nskk--okurigana-continuation-p ?a))
+        (should-not (nskk--okurigana-continuation-p ?i))
+        (should-not (nskk--okurigana-continuation-p ?u))
+        (should-not (nskk--okurigana-continuation-p ?e))
+        (should-not (nskk--okurigana-continuation-p ?o)))))
+
+  (nskk-it "returns non-nil when romaji buffer has pending input"
+    (nskk-prolog-test-with-isolated-db
+      (with-temp-buffer
+        (nskk-mode 1)
+        (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress t)
+        (setq nskk--romaji-buffer "k")
         (should (nskk--okurigana-continuation-p ?a))
-        (should (nskk--okurigana-continuation-p ?m))
-        (should (nskk--okurigana-continuation-p ?z)))))
+        (should (nskk--okurigana-continuation-p ?u))
+        (setq nskk--romaji-buffer ""))))
+
+  (nskk-it "returns nil for all lowercase when okuri-continuation-kana-emitted is set"
+    (nskk-prolog-test-with-isolated-db
+      (with-temp-buffer
+        (nskk-mode 1)
+        (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress t)
+        (nskk-state-put-metadata nskk-current-state 'okuri-continuation-kana-emitted t)
+        (should-not (nskk--okurigana-continuation-p ?a))
+        (should-not (nskk--okurigana-continuation-p ?k))
+        (should-not (nskk--okurigana-continuation-p ?z)))))
 
   (nskk-it "returns nil for uppercase A-Z even when okurigana-in-progress is set"
     (nskk-prolog-test-with-isolated-db


### PR DESCRIPTION
## Summary
- Fix semicolon key being silently consumed in direct input (ascii) mode — now inserts literal `;`
- Implement smart okurigana implicit kakutei: vowels trigger commit, consonants continue as okurigana, and after continuation kana is emitted all lowercase triggers commit
- Add AZIK deferred correction guard to prevent premature kakutei during TukaTTe-style flows

## Changes
- `nskk-input.el`: Add `(nskk-self-insert 1)` fallback in sticky-shift branch; rewrite `nskk--okurigana-continuation-p` with 4-level guard; set `okuri-continuation-kana-emitted` in `nskk--emit-converted-kana`
- `nskk-henkan.el`: Clear `okuri-continuation-kana-emitted` in `nskk-reset-henkan-state`
- `test/e2e/nskk-sticky-e2e-test.el`: +2 tests for semicolon in ascii mode
- `test/e2e/nskk-okurigana-e2e-test.el`: +4 implicit kakutei tests, updated 1 existing test
- `test/unit/nskk-input-test.el`: +3 new unit tests for continuation-p guard levels

## Test plan
- [x] Full test suite: 5548/5548 passing
- [x] Daemon verification: both bugs confirmed fixed in AZIK environment