### PR TITLE
fix: clear sticky-shift-pending on kakutei, cancel, and rollback

### DIFF
--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -206,12 +206,14 @@ exits active candidate list display: cancel, rollback, commit, exhaustion."
 (defun/done nskk-henkan-do-reset ()
   "Reset all henkan conversion state after a commit or registration.
 Clears: conversion-start-marker, pending-romaji overlay, romaji-buffer,
-henkan-count, candidate list display, and all state fields (candidates,
-okurigana, phase) via `nskk-reset-henkan-state'."
+henkan-count, candidate list display, AZIK/sticky-shift pending state,
+and all state fields (candidates, okurigana, phase) via
+`nskk-reset-henkan-state'."
   (nskk--clear-conversion-start-marker)
   (nskk--reset-romaji-buffer)
   (setq nskk--henkan-count 0)
   (nskk--dismiss-candidate-list)
+  (nskk--clear-azik-pending-state)
   (nskk-with-current-state
     (nskk-reset-henkan-state)))
 
@@ -584,19 +586,22 @@ Creates a new marker if one does not already exist."
      ,@body))
 
 (defun/done nskk--clear-azik-pending-state ()
-  "Clear AZIK okurigana sentinel variables if bound.
+  "Clear AZIK and sticky-shift pending state variables if bound.
 Resets `nskk--azik-colon-okuri-pending', `nskk--azik-colon-okuri-deferred',
-`nskk--azik-sokuon-okuri-kana-pending', `nskk--deferred-azik-state', and
-`nskk--deferred-vowel-shadow-state' to nil.  Guards each with `boundp' so
-that the function is safe to call when AZIK is not loaded.
-Called from `nskk-henkan-kakutei', `nskk-cancel-preedit', and
-`nskk-rollback-conversion' to prevent stale AZIK pending state from
+`nskk--azik-sokuon-okuri-kana-pending', `nskk--deferred-azik-state',
+`nskk--deferred-vowel-shadow-state', and `nskk--sticky-shift-pending' to
+nil.  Guards each with `boundp' so that the function is safe to call when
+AZIK or sticky-shift is not loaded.
+Called from `nskk-henkan-kakutei', `nskk-cancel-preedit',
+`nskk-rollback-conversion', `nskk-henkan-do-reset', and
+`nskk-cancel-conversion-to-reading' to prevent stale pending state from
 leaking into the next preedit context."
   (dolist (sym '(nskk--azik-colon-okuri-pending
                  nskk--azik-colon-okuri-deferred
                  nskk--azik-sokuon-okuri-kana-pending
                  nskk--deferred-azik-state
-                 nskk--deferred-vowel-shadow-state))
+                 nskk--deferred-vowel-shadow-state
+                 nskk--sticky-shift-pending))
     (when (boundp sym)
       (set sym nil))))
 
@@ -637,8 +642,8 @@ Does not reset the input mode."
 (defun/done nskk-henkan-kakutei ()
   "Commit preedit text as-is without dictionary conversion (確定).
 Removes the henkan-on marker (▽), clears the conversion start marker,
-resets the romaji buffer, clears all five AZIK pending state variables
-(see `nskk--clear-azik-pending-state'), and clears the henkan phase.
+resets the romaji buffer, clears all AZIK and sticky-shift pending state
+variables (see `nskk--clear-azik-pending-state'), and clears the henkan phase.
 When called in abbrev mode, restores the previous Japanese input mode
 via `nskk--restore-abbrev-mode'."
   (let ((was-abbrev (nskk-with-current-state
@@ -687,6 +692,7 @@ Used by `nskk-handle-q' / `nskk-toggle-japanese-mode' in ▽ preedit."
                      #'ignore))))))
   (nskk--clear-conversion-start-marker)
   (nskk--reset-romaji-buffer)
+  (nskk--clear-azik-pending-state)
   (nskk-with-current-state
     (nskk-state-set-henkan-phase nskk-current-state nil)))
 
@@ -851,6 +857,7 @@ Used by the DEL key handler."
       (nskk--reset-romaji-buffer)
       (setq nskk--henkan-count 0)
       (nskk--dismiss-candidate-list)
+      (nskk--clear-azik-pending-state)
       (nskk-with-current-state
         (nskk-reset-henkan-state)))))
 

--- a/test/e2e/nskk-sticky-e2e-test.el
+++ b/test/e2e/nskk-sticky-e2e-test.el
@@ -341,6 +341,90 @@
       (nskk-e2e-assert-henkan-phase nil)
       (nskk-e2e-assert-buffer ";k"))))
 
+;;;;
+;;;; Sticky State Cleared on Cancel / Kakutei (Regression)
+;;;;
+
+;; Regression: nskk--sticky-shift-pending was not cleared by
+;; nskk--clear-azik-pending-state, causing a stale 'immediate state
+;; after cancel or kakutei.  The next ";" would fire Arm 1
+;; (double-semicolon cancel) instead of Arm 5 (new ▽).
+
+(nskk-describe "sticky state cleared on cancel and kakutei"
+  (nskk-it "; then C-g then ; starts new preedit (not literal ;)"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-type "C-g")
+      (nskk-e2e-assert-henkan-phase nil)
+      ;; Sticky state must have been cleared by cancel-preedit.
+      ;; The next ";" must start a new ▽, not insert literal ";".
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)))
+
+  (nskk-it "; then DEL then ; starts new preedit (not literal ;)"
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-type "DEL")
+      ;; After DEL from preedit-pending, the preedit is cancelled.
+      ;; The next ";" must start a new ▽.
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)))
+
+  (nskk-it ";ka then SPC then kakutei then ; starts new preedit"
+    (let ((dict '(("か" . ("蚊" "化")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type ";")       ; → ▽
+        (nskk-e2e-type "ka")      ; → ▽か
+        (nskk-e2e-type " ")       ; → ▼蚊
+        (nskk-e2e-assert-henkan-phase 'active)
+        (nskk-e2e-type "C-j")     ; kakutei → 蚊
+        (nskk-e2e-assert-henkan-phase nil)
+        ;; Sticky state must be cleared after kakutei.
+        (nskk-e2e-type ";")
+        (nskk-e2e-assert-henkan-phase 'on))))
+
+  (nskk-it ";ka then SPC then DEL rolls back to preedit with cleared sticky state"
+    (let ((dict '(("か" . ("蚊")))))
+      (nskk-e2e-with-buffer 'hiragana dict
+        (nskk-e2e-type ";")       ; → ▽
+        (nskk-e2e-type "ka")      ; → ▽か
+        (nskk-e2e-type " ")       ; → ▼蚊
+        (nskk-e2e-assert-henkan-phase 'active)
+        ;; DEL from ▼ rolls back to ▽ (preedit), not to idle.
+        (nskk-e2e-type "DEL")
+        (nskk-e2e-assert-henkan-phase 'on)
+        ;; Sticky state must be cleared after rollback.
+        ;; ";" in ▽-with-kana arms okurigana (arm 3), not double-semicolon.
+        (nskk-e2e-type ";")
+        ;; Okurigana armed — sticky consumed, still in preedit.
+        (nskk-e2e-assert-henkan-phase 'on))))
+
+  (nskk-it ";ka then ; (arm okurigana) then C-g then ; starts new preedit"
+    ;; Regression: okurigana-armed sticky state ('okurigana) must be
+    ;; cleared by cancel-preedit, not just 'immediate.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type ";")       ; → ▽
+      (nskk-e2e-type "ka")      ; → ▽か
+      (nskk-e2e-type ";")       ; arm okurigana (sticky = 'okurigana)
+      (nskk-e2e-type "C-g")     ; cancel preedit
+      (nskk-e2e-assert-henkan-phase nil)
+      ;; Sticky must be cleared; next ";" starts new ▽.
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on)))
+
+  (nskk-it ";ka then q (script toggle) then ; starts new preedit"
+    ;; Regression: nskk-henkan-kakutei-convert-script must clear sticky.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (nskk-e2e-type ";")       ; → ▽
+      (nskk-e2e-type "ka")      ; → ▽か
+      (nskk-e2e-type "q")       ; script toggle → カ committed
+      (nskk-e2e-assert-henkan-phase nil)
+      ;; Sticky must be cleared; next ";" starts new ▽.
+      (nskk-e2e-type ";")
+      (nskk-e2e-assert-henkan-phase 'on))))
+
 (provide 'nskk-sticky-e2e-test)
 
 ;;; nskk-sticky-e2e-test.el ends here

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -2117,6 +2117,21 @@
         (should-not nskk--azik-colon-okuri-pending)
         (should-not nskk--azik-colon-okuri-deferred))))
 
+  (nskk-it "nskk--clear-azik-pending-state clears sticky-shift-pending"
+    ;; Regression: sticky-shift-pending was missing from the dolist in
+    ;; nskk--clear-azik-pending-state, causing stale sticky state after
+    ;; kakutei/cancel/rollback.
+    (with-temp-buffer
+      (let ((nskk--sticky-shift-pending 'immediate))
+        (nskk--clear-azik-pending-state)
+        (should-not nskk--sticky-shift-pending))))
+
+  (nskk-it "nskk--clear-azik-pending-state clears sticky-shift-pending in okurigana state"
+    (with-temp-buffer
+      (let ((nskk--sticky-shift-pending 'okurigana))
+        (nskk--clear-azik-pending-state)
+        (should-not nskk--sticky-shift-pending))))
+
   (nskk-it "resets nskk--henkan-candidate-list-active to nil on mode switch"
     ;; Regression test: nskk--clear-conversion-context must call
     ;; nskk--dismiss-candidate-list (not bare run-hook-with-args) so that


### PR DESCRIPTION
## Summary

- `nskk--sticky-shift-pending` was missing from `nskk--clear-azik-pending-state` dolist
- After cancel (C-g/BS) from ▽ or kakutei from ▼, sticky state survived, causing next `;` to insert literal `;` instead of entering ▽
- Added clearing calls to `nskk-henkan-do-reset`, `nskk-cancel-conversion-to-reading`, and `nskk-henkan-kakutei-convert-script`
- +2 unit tests, +6 E2E regression tests (5591/5591 passing)

## Test plan

- [x] `; → C-g → ;` enters ▽ (not literal `;`)
- [x] `; → BS → ;` enters ▽
- [x] `;ka → SPC → kakutei → ;` enters ▽
- [x] `;ka → SPC → DEL → ;` arms okurigana in ▽
- [x] `;ka → ; → C-g → ;` enters ▽ (okurigana-armed cancel)
- [x] `;ka → q → ;` enters ▽ (script-toggle path)
- [x] Zero byte-compile warnings
- [x] Live daemon verification passed all 4 scenarios