### PR TITLE
feat: 辞書登録ミニバッファでのかな入力を可能にする nskk-use-kana-in-registration を追加

### DIFF
--- a/nskk-custom.el
+++ b/nskk-custom.el
@@ -266,6 +266,17 @@ registration attempts are silently ignored."
   :package-version '(nskk . "0.1.0")
   :group 'nskk-henkan)
 
+(defcustom nskk-use-kana-in-registration nil
+  "Whether to enable NSKK kana input in the dictionary registration minibuffer.
+When non-nil, `nskk-mode' is automatically activated in hiragana mode
+in the registration minibuffer, allowing Japanese input with NSKK itself.
+When nil (default), the registration minibuffer uses plain text input,
+expecting the OS input method (e.g. macSKK) to provide Japanese input."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(nskk . "0.2.0")
+  :group 'nskk-henkan)
+
 ;;;; Candidate Window Settings
 
 (defgroup nskk-candidate-window nil

--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -1586,8 +1586,37 @@ The cleanup form guarantees two invariants on exit:
       (when (fboundp 'nskk-inline-show-registration-badge)
         (nskk-inline-show-registration-badge))
       (unwind-protect
-          (let ((entry (read-from-minibuffer
-                        (nskk--registration-prompt nskk--registration-depth reading))))
+          (let* ((entry (if nskk-use-kana-in-registration
+                           ;; nskk-mode を有効化し、辞書登録専用キーマップで
+                           ;; RET/C-j の挙動を制御する
+                           (let* ((nskk-reg-exit
+                                   (lambda ()
+                                     (interactive)
+                                     (let ((phase (nskk--compute-phase)))
+                                       (cond
+                                        ((eq phase 'converting)
+                                         (nskk-commit-current))
+                                        ((eq phase 'henkan-on)
+                                         (nskk-henkan-kakutei))
+                                        (t
+                                         (exit-minibuffer))))))
+                                  (reg-nskk-map
+                                   (let ((map (make-sparse-keymap)))
+                                     (set-keymap-parent map nskk-mode-map)
+                                     (define-key map (kbd "C-j") nskk-reg-exit)
+                                     (define-key map (kbd "RET") nskk-reg-exit)
+                                     map)))
+                             (minibuffer-with-setup-hook
+                                 (lambda ()
+                                   (nskk-mode 1)
+                                   (nskk--set-mode 'hiragana)
+                                   (setq-local minor-mode-overriding-map-alist
+                                               (list (cons 'nskk-mode reg-nskk-map))))
+                               (read-from-minibuffer
+                                (nskk--registration-prompt nskk--registration-depth reading))))
+                         ;; OS側のIMEに委ねる（デフォルト）
+                         (read-from-minibuffer
+                          (nskk--registration-prompt nskk--registration-depth reading)))))
             (unless (string-empty-p entry)
               (setq result entry)
               (nskk-dict-register-word reading entry)


### PR DESCRIPTION
## 概要

- `nskk-use-kana-in-registration` カスタム変数（デフォルト: `nil`）を追加
- 有効時、辞書登録ミニバッファで `nskk-mode` がひらがなモードで自動起動し、NSKK自体でかな入力・変換が可能になる
- `minor-mode-overriding-map-alist`（バッファローカル）を使い、グローバルなキーマップを変更せずに RET/C-j の挙動を制御

### `nskk-use-kana-in-registration` が non-nil の場合の挙動

| キー | 変換中 (▼) | プリエディット (▽) | アイドル |
|------|-----------|-------------------|---------|
| RET | 候補を確定（入力継続） | 読みを確定（入力継続） | ミニバッファ終了（辞書登録完了） |
| C-j | RET と同じ | RET と同じ | ミニバッファ終了（辞書登録完了） |

### 動機

OS側の日本語入力メソッドがない環境（WSL、Linux TTY等）では、辞書登録ミニバッファで日本語入力ができず実質的に辞書登録が不可能でした。

デフォルト（`nil`）では従来の動作を維持し、OS側のIME（macSKK等）でのミニバッファ入力を想定します。

関連: #25, #26

## テスト計画
- [ ] `nskk-use-kana-in-registration` が `nil`（デフォルト）の場合、従来通りの動作であること
- [ ] `nskk-use-kana-in-registration` が `t` の場合、辞書登録ミニバッファでかな入力できること
- [ ] 変換中に RET/C-j で候補が確定され、入力を継続できること（複合語の登録が可能）
- [ ] アイドル状態で RET/C-j でミニバッファが終了し辞書登録が完了すること
- [ ] 辞書登録後に consult 等の他のミニバッファ操作が正常に動作すること
- [ ] ネストされた辞書登録（再帰登録）が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)