### PR TITLE
fix: keep sticky shift ahead of azik semicolon dispatch

### DIFF
--- a/nskk-input.el
+++ b/nskk-input.el
@@ -414,33 +414,38 @@ nil when falling through to self-insert."
 ;;;###autoload
 (defun/k nskk-handle-semicolon-key ()
   "Handle semicolon key press.
-In AZIK mode: produce small tsu (\u3063).
+In AZIK mode: produce small tsu (\u3063) unless sticky-shift state is pending.
 In standard mode + idle Japanese: immediately insert ▽ (sticky shift).
 In standard mode + preedit with kana: arm okurigana for next char.
 Double semicolon in sticky-shift state: cancel sticky, insert literal \";\".
 In standard mode + non-Japanese mode: self-insert (on-not-found path).
 
-`on-found' is called (with t) when the key was consumed as a Japanese action:
+  `on-found' is called (with t) when the key was consumed as a Japanese action:
   AZIK small-tsu insertion, immediate ▽, okurigana armed, or sticky cancelled.
 `on-not-found' is called when key is not consumed (self-insert path)."
   :interactive t
-  (let* ((style (if (eq nskk-converter-romaji-style 'azik) 'azik 'standard))
-         (action (nskk-prolog-query-value
-                  `(semicolon-key-action ,style ,'\?action) '\?action)))
-    (nskk-debug-log "[INPUT] semicolon-key: style=%s action=%s" style action)
-    (pcase action
-      ('insert-small-tsu
-       (nskk-process-japanese-input ?\; 1)
-       (succeed t))
-      ('sticky-shift
-       (if (nskk--sticky-shift-dispatch)
-           (succeed t)
+  (if nskk--sticky-shift-pending
+      (if (nskk--sticky-shift-dispatch)
+          (succeed t)
+        (nskk-self-insert 1)
+        (fail))
+    (let* ((style (if (eq nskk-converter-romaji-style 'azik) 'azik 'standard))
+           (action (nskk-prolog-query-value
+                    `(semicolon-key-action ,style ,'\?action) '\?action)))
+      (nskk-debug-log "[INPUT] semicolon-key: style=%s action=%s" style action)
+      (pcase action
+        ('insert-small-tsu
+         (nskk-process-japanese-input ?\; 1)
+         (succeed t))
+        ('sticky-shift
+         (if (nskk--sticky-shift-dispatch)
+             (succeed t)
+           (nskk-self-insert 1)
+           (fail)))
+        ('self-insert
          (nskk-self-insert 1)
-         (fail)))
-      ('self-insert
-       (nskk-self-insert 1)
-       (fail))
-      (_ (fail)))))
+         (fail))
+        (_ (fail))))))
 
 ;;;; Input Processing
 

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -1257,7 +1257,20 @@ This ensures:
           ;; + should NOT arm colon-okurigana on US101
           (should-not nskk--azik-colon-okuri-pending))))))
 
-;;;;
+(nskk-describe "AZIK semicolon respects sticky shift"
+  (nskk-it "sticky-shift state survives AZIK style on semicolon"
+    (nskk-e2e-with-buffer 'hiragana nil
+      ;; Arm sticky shift in standard style.
+      (let ((nskk-converter-romaji-style 'standard))
+        (nskk-e2e-type ";"))
+      ;; If AZIK style becomes active before the next semicolon, the pending
+      ;; sticky-shift state must still win.
+      (let ((nskk-converter-romaji-style 'azik))
+        (nskk-e2e-type ";"))
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer ";"))))
+
+;;;; 
 ;;;; Section 17: JP106 + Key Immediate Sokuon Okurigana
 ;;;;
 ;;


### PR DESCRIPTION
## Summary
- Make pending sticky-shift state take precedence over AZIK semicolon dispatch.
- Add an E2E regression that proves semicolon still follows sticky-shift behavior even if AZIK style becomes active.

## Verification
- `make test-e2e`