### PR TITLE
feat: support custom sokuon-okurigana trigger keys via AZIK conversion table

### DIFF
--- a/nskk-azik.el
+++ b/nskk-azik.el
@@ -129,7 +129,11 @@ Affects key position-based shortcuts.
 Entries from this table are applied after the built-in AZIK rules during
 style initialization, so user-defined entries override conflicting defaults.
 Leave this as nil to use the built-in AZIK table only.  Malformed entries are
-ignored at runtime."
+ignored at runtime.
+
+Any entry that maps a single-character romaji key to \"っ\" automatically
+makes that character a sokuon-okurigana trigger in arm-eligible context
+(detected automatically during AZIK initialization)."
   :type '(repeat (list string string))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-azik)
@@ -341,6 +345,33 @@ rules in the hash (not demoted to :incomplete) and instead use the
 the next character is a vowel, the emission is retroactively replaced by the
 longer standard-romaji rule.
 Rebuilt from scratch on each call to `nskk--azik-finalize-hash-table'.")
+
+(defvar nskk--azik-sokuon-char-set (make-hash-table :test 'eql)
+  "Hash table (`:test \\='eql') mapping sokuon trigger character codes to t.
+Keys are integer character codes; values are always t (membership set).
+A character is included when its single-character romaji key maps to \"っ\"
+in `nskk--romaji-table', including any entries added via
+`nskk-azik-conversion-table' whose romaji is a single character mapping to \"っ\".
+Populated by `nskk--azik-init-sokuon-char-set' during initialization.")
+
+(defsubst nskk--azik-sokuon-key-p (char)
+  "Return non-nil if CHAR is a configured sokuon trigger key in AZIK mode.
+CHAR must be an integer character code (not a string).
+Returns nil if `nskk--azik-sokuon-char-set' has not been populated yet
+(i.e., before `nskk--azik-init-sokuon-char-set' has been called)."
+  (gethash char nskk--azik-sokuon-char-set))
+
+(defun/done nskk--azik-init-sokuon-char-set ()
+  "Populate `nskk--azik-sokuon-char-set' from `nskk--romaji-table' entries mapping to っ.
+Iterates `nskk--romaji-table' directly (not Prolog azik-rule/2 facts); includes
+only entries whose key has length 1 and whose value is exactly \"っ\".
+Must be called after all azik-rule facts and user overrides are applied."
+  (clrhash nskk--azik-sokuon-char-set)
+  (maphash (lambda (k v)
+             (when (and (= (length k) 1)
+                        (equal v "っ"))
+               (puthash (aref k 0) t nskk--azik-sokuon-char-set)))
+           nskk--romaji-table))
 
 (defun/done nskk--azik-init-char-facts ()
   "Assert azik-vowel-char/1 for each Japanese romaji vowel character code.
@@ -606,6 +637,9 @@ The hash table is populated from azik-rule/2 for hot-path lookups."
   (dolist (rule nskk-azik-conversion-table)
     (when (nskk--azik-conversion-rule-p rule)
       (nskk-converter-add-rule (car rule) (cadr rule))))
+
+  ;; Build sokuon char set from finalized hash (includes user overrides).
+  (nskk--azik-init-sokuon-char-set)
 
   (nskk--setup-azik-toggle-key))
 

--- a/nskk-input.el
+++ b/nskk-input.el
@@ -97,6 +97,7 @@
 (declare-function nskk-state-mode "nskk-state")
 (declare-function nskk-converter-load-style "nskk-converter")
 (declare-function nskk-converter-convert "nskk-converter")
+(declare-function nskk--azik-sokuon-key-p "nskk-azik")
 (declare-function nskk-kana-string-hiragana-to-katakana "nskk-kana")
 (declare-function nskk-kana-zenkaku-to-hankaku "nskk-kana")
 ;; From nskk-henkan.el:
@@ -751,6 +752,9 @@ CHAR-TYPE -- character classification:
   `alphabetic-lower'   -- ASCII a-z
   `plus-jp106'         -- `+' on JP106 keyboard (immediate sokuon okurigana)
   `colon'              -- the `:' character
+  `sokuon-trigger'     -- single-char key mapped to っ in AZIK (empty buffer);
+                          fires okuri-sokuon only in azik-arm-eligible context,
+                          falls through to normal-romaji in other contexts
   `other'              -- anything else
 
 Actions:
@@ -765,6 +769,10 @@ Actions:
                  (characterp char) (<= ?a char) (<= char ?z))
         (setq char (upcase char)))))
   (let* ((char-type (cond
+                        ((and (eq nskk-converter-romaji-style 'azik)
+                              (characterp char) (<= ?a char) (<= char ?z)
+                              (string-empty-p nskk--romaji-buffer)
+                              (nskk--azik-sokuon-key-p char))               'sokuon-trigger)
                         ((and (characterp char) (<= ?a char) (<= char ?z)) 'alphabetic-lower)
                         ((and (eq char ?+)
                               (bound-and-true-p nskk-azik-keyboard-type)
@@ -1272,6 +1280,7 @@ Arguments (all pre-computed classification symbols):
                `alphabetic-lower'    -- ASCII a-z
                `plus-jp106'          -- `+' on JP106 keyboard
                `colon'               -- the `:' character
+               `sokuon-trigger'      -- single-char key mapped to っ in AZIK
                `other'               -- anything else
 Result (first arg):
   `fire'        -- call nskk--fire-azik-colon-okuri
@@ -1282,6 +1291,7 @@ Result (first arg):
     (fire         colon-pending      alphabetic-lower)
     (arm          azik-arm-eligible  colon)
     (okuri-sokuon azik-arm-eligible  plus-jp106)
+    (okuri-sokuon azik-arm-eligible  sokuon-trigger)
     (normal       \?ctx              \?ct)))
 
 (defun/done nskk--init-doubled-context-rules ()

--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -123,6 +123,13 @@
 ;; Functions in nskk-henkan.el
 (declare-function nskk-converting-p "nskk-henkan")
 (declare-function nskk--has-preedit "nskk-henkan")
+(declare-function nskk--conversion-start-active-p "nskk-henkan")
+;; Functions in nskk-input.el
+(declare-function nskk--trigger-sokuon-okurigana "nskk-input")
+;; Functions in nskk-azik.el
+(declare-function nskk--azik-sokuon-key-p "nskk-azik")
+(declare-function nskk-state-get-okurigana "nskk-state")
+(defvar nskk--sticky-shift-pending)
 (declare-function nskk--get-conversion-start "nskk-henkan")
 (declare-function nskk-start-conversion "nskk-henkan")
 (declare-function nskk-next-candidate "nskk-henkan")
@@ -201,15 +208,19 @@
 ;; l-key-action/3: AZIK-aware dispatch for the l key.
 ;; (l-key-action STYLE BUF-STATE ACTION)
 ;; STYLE is `azik' or `standard' (from nskk-converter-romaji-style).
-;; BUF-STATE is `azik-complete' when pending-romaji+l forms a complete rule
-;; match (AZIK hash or standard romaji rule); `other' otherwise.  Both styles
-;; map `azik-complete' to fire-romaji (e.g. "zl" -> "->" in standard mode) and
-;; `other' to latin-mode.
+;; BUF-STATE values:
+;;   `sokuon-eligible' -- AZIK style only; romaji buffer is empty, a conversion
+;;     start is active, preedit exists, no okurigana in progress, colon-okuri
+;;     is not pending, and l is a valid AZIK sokuon key → trigger sokuon-okurigana.
+;;   `azik-complete'   -- pending-romaji+l forms a complete rule match (AZIK hash
+;;     or standard romaji rule); maps to fire-romaji (e.g. "zl" -> "->").
+;;   `other'           -- all remaining cases; maps to latin-mode.
 (nskk-prolog-define-fact-table l-key-action (:arity 3 :index :hash)
-  (azik     azik-complete fire-romaji)
-  (azik     other         latin-mode)
-  (standard azik-complete fire-romaji)
-  (standard other         latin-mode))
+  (azik     sokuon-eligible         trigger-sokuon-okurigana)
+  (azik     azik-complete           fire-romaji)
+  (azik     other                   latin-mode)
+  (standard azik-complete           fire-romaji)
+  (standard other                   latin-mode))
 
 ;;;; Kakutei Idle-State Classification Rules
 
@@ -569,16 +580,31 @@ Dispatched via `q-key-dispatch/3' Prolog table."
 
 (defun/done nskk--handle-l-action ()
   "Helper for `nskk-handle-l' mode-switch and fire-romaji actions.
-Dispatched via `l-key-action/3' Prolog table (style, buf-state, action)."
+Dispatched via `l-key-action/3' Prolog table (style, buf-state, action).
+In AZIK style, when l is a sokuon key and conditions are met, triggers
+sokuon-okurigana instead of switching to latin mode."
   (let* ((style (if (eq nskk-converter-romaji-style 'azik) 'azik 'standard))
-         (buf-state (if (or (nskk--azik-complete-match-p ?l)
-                            (nskk--romaji-has-match-p ?l))
-                        'azik-complete
-                      'other))
+         (buf-state (cond
+                      ((and (eq nskk-converter-romaji-style 'azik)
+                            (not nskk--azik-colon-okuri-pending)
+                            (nskk--azik-sokuon-key-p ?l)
+                            (string-empty-p nskk--romaji-buffer)
+                            (nskk--conversion-start-active-p)
+                            (nskk--has-preedit)
+                            (not (nskk-with-current-state
+                                   (nskk-state-get-okurigana nskk-current-state))))
+                       'sokuon-eligible)
+                      ((or (nskk--azik-complete-match-p ?l)
+                           (nskk--romaji-has-match-p ?l))
+                       'azik-complete)
+                      (t 'other)))
          (action (nskk-prolog-query-value
                   `(l-key-action ,style ,buf-state ,'\?a) '\?a)))
     (pcase action
       ('fire-romaji (nskk-process-japanese-input ?l 1))
+      ('trigger-sokuon-okurigana
+       (setq nskk--sticky-shift-pending nil)
+       (nskk--trigger-sokuon-okurigana))
       ('latin-mode
        (nskk--with-japanese-mode/k
          (lambda (_) (nskk-set-mode-latin))
@@ -586,8 +612,10 @@ Dispatched via `l-key-action/3' Prolog table (style, buf-state, action)."
       (_ (self-insert-command 1)))))
 
 (defun/done nskk-handle-l ()
-  "Handle l key: candidate selection, romaji rule, or mode toggle.
+  "Handle l key: candidate selection, romaji rule, sokuon-okurigana, or mode toggle.
 In candidate list selection mode, the key acts as a selection key.
+In AZIK style with an active preedit and no okurigana or colon-okuri pending,
+triggers sokuon-okurigana when l qualifies as a sokuon key.
 In idle Japanese mode, switches to ASCII (latin) mode or fires a romaji rule.
 In ASCII mode or when NSKK state is inactive, falls through to
 `self-insert-command'."

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -1617,6 +1617,103 @@ This ensures:
         (nskk-e2e-type "v")
         (nskk-e2e-assert-buffer "わかす")))))
 
+;;;;
+;;;; Section 22: Custom Sokuon-Okurigana Trigger Key (l → っ via conversion table)
+;;;;
+;;
+;; When the user maps a key to っ via nskk-azik-conversion-table, that key
+;; automatically becomes a sokuon-okurigana trigger in arm-eligible context
+;; (AZIK style + active preedit + empty romaji buffer + no okurigana pending).
+;; These tests use `("l" "っ")' as the representative user mapping.
+
+(nskk-describe "§22: Custom sokuon-okurigana trigger via nskk-azik-conversion-table"
+
+  (nskk-it "T-01: l in preedit triggers sokuon-okurigana and enters conversion state"
+    ;; Ka starts preedit (▽か).  l with romaji-buffer empty and no okurigana
+    ;; pending qualifies as sokuon-eligible → trigger-sokuon-okurigana action.
+    ;; The dict fires on reading かt, producing ▼買 (or registration dialog).
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (let ((dict '(("かt" . ("買")))))
+        (nskk-e2e-with-azik-buffer 'hiragana dict
+          (nskk-e2e-type "Ka")
+          (nskk-e2e-type "l")
+          (should (string-match-p "▼" (buffer-string)))))))
+
+  (nskk-it "T-02: Ka l C-j ta produces 買った"
+    ;; Steps: Ka → ▽か / l → ▼買 / C-j → commits 買 / ta → った
+    ;; Full commit: Ka starts preedit, l fires sokuon-okurigana (key=?t),
+    ;; C-j commits the candidate (買), then ta produces った.
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (let ((dict '(("かt" . ("買")))))
+        (nskk-e2e-with-azik-buffer 'hiragana dict
+          (nskk-e2e-type "Ka")
+          (nskk-e2e-type "l")
+          (nskk-e2e-type "C-j")
+          (nskk-e2e-type "ta")
+          (nskk-e2e-assert-buffer "買った")))))
+
+  (nskk-it "T-03: nskk--azik-sokuon-okuri-kana-pending is set after l fires sokuon trigger"
+    ;; Mirror the §17 SP-flag test (nskk-e2e--dispatch-event ?+) but using l.
+    ;; After l fires sokuon-okurigana, the sentinel flag must be non-nil so that
+    ;; the next kana emission can clear okurigana-in-progress correctly.
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (let ((dict '(("かt" . ("買")))))
+        (nskk-e2e-with-azik-buffer 'hiragana dict
+          (nskk-e2e-type "Ka")
+          (nskk-e2e-type "l")
+          (should (bound-and-true-p nskk--azik-sokuon-okuri-kana-pending))))))
+
+  (nskk-it "T-04: C-g after Ka l clears nskk--azik-sokuon-okuri-kana-pending"
+    ;; Cancel path: after l fires sokuon-okurigana, C-g must clear the
+    ;; sentinel so the next preedit session does not start with a stale flag.
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (let ((dict '(("かt" . ("買")))))
+        (nskk-e2e-with-azik-buffer 'hiragana dict
+          (nskk-e2e-type "Ka")
+          (nskk-e2e-type "l")
+          (nskk-e2e-type "C-g")
+          (should (not (bound-and-true-p nskk--azik-sokuon-okuri-kana-pending)))))))
+
+  (nskk-it "T-05: kl in preedit produces こん (AZIK hatsuon), not sokuon trigger"
+    ;; Regression guard: when romaji-buffer is non-empty (k pending), l
+    ;; completes the kl hatsuon rule (こん) via normal AZIK romaji processing.
+    ;; The sokuon-eligible guard requires an empty romaji buffer.
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (nskk-e2e-with-azik-buffer 'hiragana nil
+        (nskk-e2e-type "K")
+        (nskk-e2e-type "l")
+        ;; kl fires the built-in hatsuon rule → reading is こん, still in preedit
+        (should (string-match-p "こん" (buffer-string))))))
+
+  (nskk-it "T-06: l in idle hiragana mode produces っ when l is mapped to っ"
+    ;; When l maps to っ in the custom table, pressing l in idle hiragana mode
+    ;; (no active preedit, empty romaji buffer) fires the romaji rule directly
+    ;; and inserts っ.  The l-key-action dispatch uses `azik-complete' context
+    ;; (nskk--romaji-has-match-p true) → fire-romaji, not latin-mode.
+    ;; This is correct: latin-mode only applies when l has no romaji match.
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (nskk-e2e-with-azik-buffer 'hiragana nil
+        (nskk-e2e-type "l")
+        (nskk-e2e-assert-buffer "っ"))))
+
+  (nskk-it "T-07: nskk--sticky-shift-pending is cleared when l triggers sokuon-okurigana"
+    ;; Verifies FR-005: nskk--sticky-shift-pending is cleared before
+    ;; nskk--trigger-sokuon-okurigana is called, preventing the flag from
+    ;; leaking into subsequent input.
+    ;; Note: In AZIK jp106, typing `;' inserts っ (not sticky-shift), so
+    ;; the pending flag is set programmatically to isolate the clearing behaviour.
+    ;; Steps: Ka → ▽か / [arm sticky] / l → ▼買 / C-j → commits 買 / ta → った
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (let ((dict '(("かt" . ("買")))))
+        (nskk-e2e-with-azik-buffer 'hiragana dict
+          (nskk-e2e-type "Ka")                            ; → ▽か
+          (setq nskk--sticky-shift-pending 'okurigana)    ; arm sticky programmatically
+          (nskk-e2e-type "l")                             ; l fires sokuon-okurigana, clears sticky
+          (nskk-e2e-type "C-j")                           ; commit 買
+          (nskk-e2e-type "ta")                            ; → った
+          (nskk-e2e-assert-buffer "買った")
+          (should (null nskk--sticky-shift-pending)))))))
+
 (provide 'nskk-azik-e2e-test)
 
 ;;; nskk-azik-e2e-test.el ends here

--- a/test/unit/nskk-azik-test.el
+++ b/test/unit/nskk-azik-test.el
@@ -2265,6 +2265,50 @@
     (nskk-with-azik-style
       (should-not (nskk-prolog-holds-p '(azik-colon-trigger-char ?a))))))
 
+;;;;
+;;;; nskk--azik-sokuon-char-set population tests
+;;;;
+
+(nskk-describe "nskk--azik-sokuon-char-set: standard AZIK rules"
+  (nskk-it "semicolon is a sokuon key in standard AZIK (maps to っ)"
+    (nskk-with-azik-style
+      (should (nskk--azik-sokuon-key-p ?;))))
+
+  (nskk-it "alphabetic vowel a is not a sokuon key"
+    (nskk-with-azik-style
+      (should-not (nskk--azik-sokuon-key-p ?a))))
+
+  (nskk-it "consonant k is not a sokuon key"
+    (nskk-with-azik-style
+      (should-not (nskk--azik-sokuon-key-p ?k)))))
+
+(nskk-describe "nskk--azik-sokuon-char-set: custom conversion table adds l as sokuon key"
+  (nskk-it "l is detected as a sokuon key when user maps l to っ"
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (nskk-with-azik-style
+        (should (nskk--azik-sokuon-key-p ?l)))))
+
+  (nskk-it "q is not a sokuon key even though it maps to ん (not っ)"
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (nskk-with-azik-style
+        (should-not (nskk--azik-sokuon-key-p ?q)))))
+
+  (nskk-it "semicolon remains a sokuon key when user also maps l to っ"
+    (let ((nskk-azik-conversion-table '(("l" "っ"))))
+      (nskk-with-azik-style
+        (should (nskk--azik-sokuon-key-p ?;))))))
+
+(nskk-describe "nskk--azik-sokuon-char-set: JP106 + key is a sokuon key"
+  (nskk-it "+ is a sokuon key under JP106 keyboard type"
+    (let ((nskk-azik-keyboard-type 'jp106))
+      (nskk-with-azik-style
+        (should (nskk--azik-sokuon-key-p ?+)))))
+
+  (nskk-it "+ is not a sokuon key under US101 keyboard type"
+    (let ((nskk-azik-keyboard-type 'us101))
+      (nskk-with-azik-style
+        (should-not (nskk--azik-sokuon-key-p ?+))))))
+
 (provide 'nskk-azik-test)
 
 ;;; nskk-azik-test.el ends here

--- a/test/unit/nskk-input-test.el
+++ b/test/unit/nskk-input-test.el
@@ -2200,6 +2200,34 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
           (nskk-converter-load-style 'standard)
           (nskk-prolog-retract-all 'azik-rule 2))))))
 
+;;;
+;;; japanese-input-class/3 sokuon-trigger row tests
+;;;
+
+(nskk-describe "japanese-input-class/3 sokuon-trigger dispatch"
+  (nskk-it "azik-arm-eligible + sokuon-trigger maps to okuri-sokuon"
+    ;; When the input context is azik-arm-eligible (AZIK style, active preedit,
+    ;; no okurigana pending) and the char-type is sokuon-trigger (a custom table
+    ;; key mapped to っ), the dispatch result must be okuri-sokuon so that
+    ;; nskk--trigger-sokuon-okurigana is called.
+    (nskk-prolog-test-with-isolated-db
+      (nskk-input-initialize)
+      (should (eq (nskk-prolog-query-value
+                   `(japanese-input-class ,'\?action azik-arm-eligible sokuon-trigger)
+                   '\?action)
+                  'okuri-sokuon))))
+
+  (nskk-it "other context + sokuon-trigger falls through to normal"
+    ;; Outside azik-arm-eligible context (e.g. idle or non-AZIK style), the
+    ;; sokuon-trigger char-type must fall through to the wildcard row and
+    ;; return normal so the key is handled as regular romaji input.
+    (nskk-prolog-test-with-isolated-db
+      (nskk-input-initialize)
+      (should (eq (nskk-prolog-query-value
+                   `(japanese-input-class ,'\?action other sokuon-trigger)
+                   '\?action)
+                  'normal)))))
+
 (provide 'nskk-input-test)
 
 ;;; nskk-input-test.el ends here

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -1484,7 +1484,12 @@ and configures state."
     ;; (e.g. "zl" -> "->").
     (should (eq (nskk-prolog-query-value
                  `(l-key-action standard azik-complete ,'\?action) '\?action)
-                'fire-romaji))))
+                'fire-romaji)))
+
+  (nskk-it "azik + sokuon-eligible maps to trigger-sokuon-okurigana"
+    (should (eq (nskk-prolog-query-value
+                 `(l-key-action azik sokuon-eligible ,'\?action) '\?action)
+                'trigger-sokuon-okurigana))))
 
 ;;;
 ;;; state-classify/4 Prolog Table Tests


### PR DESCRIPTION
## Summary

- Any single-char key mapping to `っ` in `nskk-azik-conversion-table` now acts as a sokuon-okurigana trigger in arm-eligible context, mirroring the built-in JP106 `+` key behaviour
- Motivated by custom AZIK layouts (e.g. `l`→`っ`) so that `Ka`+`l`+`ta` → 買った works naturally
- `nskk--sticky-shift-pending` is cleared before `nskk--trigger-sokuon-okurigana` fires (FR-005)
- All existing behaviour preserved: JP106 `+`, PREFIX+l hatsuon rules (こん/とん etc.), and latin-mode switch when outside preedit

## Changes

| File | Change |
|------|--------|
| `nskk-azik.el` | `nskk--azik-sokuon-char-set` hash table + `nskk--azik-sokuon-key-p` predicate + `nskk--azik-init-sokuon-char-set` (called at finalize time after user overrides) |
| `nskk-input.el` | New `sokuon-trigger` char-type; new `japanese-input-class/3` fact `(okuri-sokuon azik-arm-eligible sokuon-trigger)` |
| `nskk-keymap.el` | New `sokuon-eligible` buf-state + `l-key-action/3` row `(azik sokuon-eligible trigger-sokuon-okurigana)`; sticky-shift clear before trigger |

## Test plan

- [ ] 10 new unit tests: `nskk--azik-sokuon-char-set` population (standard/custom/JP106), `l-key-action/3` sokuon-eligible row, `japanese-input-class/3` sokuon-trigger rows
- [ ] 7 new E2E tests in §22: basic `l` trigger, full 買った flow, pending flag set/cleared, `kl`→こん hatsuon regression, `l` in idle hiragana, sticky-shift-pending clearing
- [ ] Full suite: 5609/5609 passing (was 5606 before this PR)