### PR TITLE
fix: commit conversion when AZIK toggle key pressed during henkan-active

### DIFF
--- a/nskk-input.el
+++ b/nskk-input.el
@@ -119,6 +119,8 @@
 (declare-function nskk-cancel-preedit "nskk-henkan")
 (declare-function nskk--show-pending-romaji "nskk-henkan" (text))
 (declare-function nskk--clear-pending-romaji "nskk-henkan" ())
+(declare-function nskk--classify-state "nskk-keymap" ())
+(declare-function nskk--with-japanese-mode/k "nskk-keymap" (on-found on-not-found))
 (defvar nskk--romaji-buffer)                         ;; Forward declaration from nskk-state.el
 (defvar nskk-henkan-on-marker)                        ;; Forward declaration from nskk-henkan.el
 (defvar nskk--conversion-start-marker)               ;; Forward declaration from nskk-state.el
@@ -278,31 +280,39 @@ Dictionary keys that begin with # trigger numeric candidate expansion."
 
 ;;;###autoload
 (defun/done nskk-toggle-japanese-mode ()
-  "Convert preedit kana to opposite script, or toggle hiragana<->katakana.
-In ▽ preedit phase (henkan-phase `on'): delegates to
-`nskk-henkan-kakutei-convert-script' which queries `script-toggle/2'
-(Prolog) for the target script, converts and commits the preedit text,
-and clears conversion state without changing the input mode.
-In idle state: queries `toggle-mode/2' (Prolog) for the target mode and
-switches via `nskk--set-mode' (hiragana↔katakana toggle).
-Falls through to `self-insert-command' when no toggle-mode fact exists for
-the current mode (e.g. ascii, latin), so that the AZIK toggle key (@/[)
-self-inserts in non-Japanese modes."
+  "Toggle Japanese input mode, with phase-aware dispatch.
+Uses `nskk--classify-state' to determine the current phase:
+- `converting' (▼): implicit kakutei via
+  `nskk--with-japanese-mode/k', then toggle mode.
+- `preedit-japanese' (▽): convert preedit kana to opposite
+  script via `nskk-henkan-kakutei-convert-script'.
+- `preedit-pending': implicit kakutei, then toggle mode.
+- `idle-japanese': toggle hiragana<->katakana via
+  `toggle-mode/2' and `nskk--set-mode'.
+- Otherwise: `self-insert-command' (AZIK @/[ self-inserts)."
   :interactive t
-  (if (nskk-with-current-state
-        (nskk-prolog-holds-p
-         `(preedit-phase ,(nskk-state-henkan-phase nskk-current-state))))
-      (nskk-henkan-kakutei-convert-script)
-    (let* ((current-mode (when (boundp 'nskk-current-state)
-                           (nskk-state-mode nskk-current-state)))
-           (target (nskk-prolog-query-value
-                    `(toggle-mode ,current-mode ,'\?target) '\?target)))
-      (if target
-          (progn
-            (nskk-debug-log "[INPUT] toggle-mode: from=%s to=%s" current-mode target)
-            (nskk--set-mode target)
-            (nskk--update-modeline))
-        (self-insert-command 1)))))
+  (cl-flet ((do-toggle ()
+              (let* ((mode (nskk-state-mode nskk-current-state))
+                     (target (nskk-prolog-query-value
+                              `(toggle-mode ,mode ,'\?target)
+                              '\?target)))
+                (when target
+                  (nskk-debug-log "[INPUT] toggle-mode: from=%s to=%s"
+                                  mode target)
+                  (nskk--set-mode target)
+                  (nskk--update-modeline)
+                  t))))
+    (pcase (nskk--classify-state)
+      ((or 'converting 'preedit-pending)
+       (nskk--with-japanese-mode/k
+        (lambda (_) (do-toggle))
+        (lambda () (self-insert-command 1))))
+      ('preedit-japanese
+       (nskk-henkan-kakutei-convert-script))
+      ('idle-japanese
+       (unless (do-toggle) (self-insert-command 1)))
+      (_
+       (self-insert-command 1)))))
 
 (defun/done nskk--set-mode (mode)
   "Internal mode setter with validation.

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -454,6 +454,82 @@ This ensures:
         (nskk-e2e-assert-buffer "")))))
 
 ;;;;
+;;;; Section 6b: AZIK Toggle Key During Henkan-Active (Issue #34)
+;;;;
+
+(nskk-describe "AZIK toggle key commits conversion during henkan-active"
+
+  (nskk-it "@ key during ▼ commits conversion and toggles to katakana (jp106)"
+    ;; When ▼山 is displayed and @ is pressed, the conversion should be
+    ;; committed (kakutei) and mode toggled to katakana.
+    ;; This is the jp106 equivalent of the us101 bug in issue #34.
+    ;; NOTE: Use "Yama" not "Kanji" because AZIK remaps nj → non-standard kana.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "Yama")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-type "SPC")
+      (nskk-e2e-assert-henkan-phase 'active)
+      (nskk-e2e-type "@")
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer "山")
+      (nskk-e2e-assert-mode 'katakana)))
+
+  (nskk-it "[ key during ▼ commits conversion and toggles to katakana (us101)"
+    ;; Issue #34: pressing [ during ▼山 should commit and toggle mode.
+    ;; Previously this reverted to ▽ instead of committing.
+    (let ((nskk-azik-keyboard-type 'us101))
+      (nskk--setup-azik-toggle-key)
+      (nskk-e2e-with-azik-buffer 'hiragana nil
+        (nskk-e2e-type "Yama")
+        (nskk-e2e-assert-henkan-phase 'on)
+        (nskk-e2e-type "SPC")
+        (nskk-e2e-assert-henkan-phase 'active)
+        (nskk-e2e-type "[")
+        (nskk-e2e-assert-henkan-phase nil)
+        (nskk-e2e-assert-buffer "山")
+        (nskk-e2e-assert-mode 'katakana))))
+
+  (nskk-it "@ key during ▽ converts script and commits (existing behavior preserved)"
+    ;; In ▽ preedit, @ converts kana to opposite script (hiragana→katakana)
+    ;; and commits without changing the input mode.
+    ;; NOTE: Use "Yama" not "Kanji" because AZIK remaps nj → non-standard kana.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "Yama")
+      (nskk-e2e-assert-henkan-phase 'on)
+      (nskk-e2e-type "@")
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer "ヤマ")
+      (nskk-e2e-assert-mode 'hiragana)))
+
+  (nskk-it "[ key in idle hiragana toggles to katakana (existing behavior preserved)"
+    ;; Idle toggle should still work as before.
+    (let ((nskk-azik-keyboard-type 'us101))
+      (nskk--setup-azik-toggle-key)
+      (nskk-e2e-with-azik-buffer 'hiragana nil
+        (nskk-e2e-assert-mode 'hiragana)
+        (nskk-e2e-type "[")
+        (nskk-e2e-assert-mode 'katakana))))
+
+  (nskk-it "[ key in ascii mode self-inserts (existing behavior preserved)"
+    ;; In ascii/latin mode, the toggle key should self-insert.
+    (let ((nskk-azik-keyboard-type 'us101))
+      (nskk--setup-azik-toggle-key)
+      (nskk-e2e-with-azik-buffer nil nil
+        (nskk-e2e-type "[")
+        (nskk-e2e-assert-buffer "["))))
+
+  (nskk-it "@ key during preedit-pending clears marker and toggles mode"
+    ;; When uppercase trigger fired (▽ marker set) but no kana emitted yet,
+    ;; @ should clear the preedit marker and toggle to katakana.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "K")               ; uppercase K starts henkan (▽)
+      (nskk-e2e-assert-henkan-phase 'on) ; marker set, no kana yet
+      (nskk-e2e-type "@")
+      (nskk-e2e-assert-henkan-phase nil)
+      (nskk-e2e-assert-buffer "")
+      (nskk-e2e-assert-mode 'katakana))))
+
+;;;;
 ;;;; Section 7: AZIK Standard Romaji Compatibility in E2E Buffer
 ;;;;
 


### PR DESCRIPTION
## Summary
- AZIK有効時にトグルキー（jp106: `@`, us101: `[`）を▼変換中に押すと、変換が確定されずに▽に戻る問題を修正
- `nskk-toggle-japanese-mode` を `nskk--classify-state` ディスパッチにリファクタリングし、`nskk--with-japanese-mode/k` による implicit kakutei を実装
- 6つのE2Eテストを追加（jp106/us101での▼確定、▽スクリプト変換、idle切替、ascii self-insert、preedit-pending）

## Test plan
- [x] 全5597テスト通過（0回帰）
- [x] `@` during ▼ commits and toggles (jp106)
- [x] `[` during ▼ commits and toggles (us101)
- [x] `@` during ▽ converts script (preserved)
- [x] `[` in idle toggles mode (preserved)
- [x] `[` in ascii self-inserts (preserved)
- [x] `@` during preedit-pending clears and toggles
- [x] Byte-compile: 0 warnings

Closes #34