### PR TITLE
fix: cancel dictionary registration with C-g

### DIFF
--- a/nskk-henkan.el
+++ b/nskk-henkan.el
@@ -1565,97 +1565,93 @@ DEPTH 1 → \"[辞書登録] READING: \", DEPTH 2 → \"[[辞書登録]] READING
         (close (make-string depth ?\])))
     (format "%s辞書登録%s %s: " open close reading)))
 
-(defun nskk--run-registration-session (reading)
-  "Open the minibuffer for registering READING; return the entered string or nil.
-Manages `nskk--registration-depth' and restores the henkan-phase via
-`unwind-protect', so depth and phase are always consistent on exit.
+(defun nskk--read-registration-entry-with-kana (prompt)
+  "Read a registration entry from the minibuffer for PROMPT with nskk-mode active.
+Sets up a dedicated keymap so RET and C-j commit the current conversion
+instead of exiting with a raw newline."
+  (let* ((exit-fn (lambda ()
+                    (interactive)
+                    (let ((phase (nskk--compute-phase)))
+                      (cond
+                       ((eq phase 'converting) (nskk-commit-current))
+                       ((eq phase 'henkan-on) (nskk-henkan-kakutei))
+                       (t (exit-minibuffer))))))
+         (reg-map (let ((map (make-sparse-keymap)))
+                    (set-keymap-parent map nskk-mode-map)
+                    (define-key map (kbd "C-j") exit-fn)
+                    (define-key map (kbd "RET") exit-fn)
+                    map)))
+    (minibuffer-with-setup-hook
+        (lambda ()
+          (nskk-mode 1)
+          (nskk--set-mode 'hiragana)
+          (setq-local minor-mode-overriding-map-alist
+                      (list (cons 'nskk-mode reg-map))))
+      (read-from-minibuffer prompt))))
 
-`unwind-protect' is mandatory here because the user can abort at any time
-via \[keyboard-quit] or if an error is signalled inside
-`read-from-minibuffer'.  Without the cleanup form the depth counter would
-remain incremented, blocking future registration attempts.
+(defun nskk--read-registration-entry (reading)
+  "Read a registration entry for READING from the minibuffer.
+Returns the entered non-empty string, or nil if the user cancels
+\(empty input or C-g).
+Uses `nskk-use-kana-in-registration' to choose the input method."
+  (condition-case nil
+      (let ((entry (if nskk-use-kana-in-registration
+                      (nskk--read-registration-entry-with-kana
+                       (nskk--registration-prompt nskk--registration-depth reading))
+                    (read-from-minibuffer
+                     (nskk--registration-prompt nskk--registration-depth reading)))))
+        (and (not (string-empty-p entry)) entry))
+    (quit nil)))
 
-`nskk--registration-depth' tracks nested (recursive) registration: each
-call increments it before opening the minibuffer and decrements it in the
-cleanup form, regardless of how the minibuffer session ends.  This allows
-the user to register a word for an unknown reading that itself appeared
-during registration (e.g. registering \"かんじ\" → user types \"漢字\" →
-\"漢\" is unknown → nested call for \"かん\"), up to
-`nskk-max-registration-depth' levels.
+(defun nskk--commit-registration-word (reading entry)
+  "Register ENTRY for READING in the dictionary and update learning state."
+  (nskk-dict-register-word reading entry)
+  (when (fboundp 'nskk-study-after-kakutei)
+    (nskk-study-after-kakutei reading entry))
+  (nskk-search-learn reading entry))
 
-The cleanup form guarantees two invariants on exit:
-  1. `nskk--registration-depth' is decremented (preventing leaks).
-  2. The henkan-phase is restored to its value before registration."
-  (when (< nskk--registration-depth nskk-max-registration-depth)
-    (let ((prev-phase (nskk-state-henkan-phase nskk-current-state))
-          (result nil))
-      (nskk-with-current-state
-        (nskk-state-force-henkan-phase nskk-current-state 'registration))
-      (cl-incf nskk--registration-depth)
-      ;; Show inline registration badge when inline display is enabled
-      (when (fboundp 'nskk-inline-show-registration-badge)
-        (nskk-inline-show-registration-badge))
-      (unwind-protect
-          (let* ((entry (if nskk-use-kana-in-registration
-                           ;; nskk-mode を有効化し、辞書登録専用キーマップで
-                           ;; RET/C-j の挙動を制御する
-                           (let* ((nskk-reg-exit
-                                   (lambda ()
-                                     (interactive)
-                                     (let ((phase (nskk--compute-phase)))
-                                       (cond
-                                        ((eq phase 'converting)
-                                         (nskk-commit-current))
-                                        ((eq phase 'henkan-on)
-                                         (nskk-henkan-kakutei))
-                                        (t
-                                         (exit-minibuffer))))))
-                                  (reg-nskk-map
-                                   (let ((map (make-sparse-keymap)))
-                                     (set-keymap-parent map nskk-mode-map)
-                                     (define-key map (kbd "C-j") nskk-reg-exit)
-                                     (define-key map (kbd "RET") nskk-reg-exit)
-                                     map)))
-                             (minibuffer-with-setup-hook
-                                 (lambda ()
-                                   (nskk-mode 1)
-                                   (nskk--set-mode 'hiragana)
-                                   (setq-local minor-mode-overriding-map-alist
-                                               (list (cons 'nskk-mode reg-nskk-map))))
-                               (read-from-minibuffer
-                                (nskk--registration-prompt nskk--registration-depth reading))))
-                         ;; OS側のIMEに委ねる（デフォルト）
-                         (read-from-minibuffer
-                          (nskk--registration-prompt nskk--registration-depth reading)))))
-            (unless (string-empty-p entry)
-              (setq result entry)
-              (nskk-dict-register-word reading entry)
-              ;; Study + frequency learning for newly registered words.
-              (when (fboundp 'nskk-study-after-kakutei)
-                (nskk-study-after-kakutei reading entry))
-              (nskk-search-learn reading entry)))
-        (cl-decf nskk--registration-depth)
-        ;; Hide inline badge on exit
-        (when (fboundp 'nskk-inline-hide)
-          (nskk-inline-hide))
+(defun nskk--run-registration-session/k (reading on-found _on-not-found)
+  "Open the minibuffer for registering READING.
+Calls ON-FOUND with the registered word string on success, or nil if the
+user cancels.  _ON-NOT-FOUND is unused.
+
+Manages `nskk--registration-depth' and the henkan-phase via
+`unwind-protect', so both are always restored on exit.  Delegates input
+to `nskk--read-registration-entry' and commit to
+`nskk--commit-registration-word'.  [CPS]"
+  (if (< nskk--registration-depth nskk-max-registration-depth)
+      (let ((prev-phase (nskk-state-henkan-phase nskk-current-state))
+            (result nil))
         (nskk-with-current-state
-          (nskk-state-force-henkan-phase nskk-current-state prev-phase)))
-      result)))
+          (nskk-state-force-henkan-phase nskk-current-state 'registration))
+        (cl-incf nskk--registration-depth)
+        (unwind-protect
+            (progn
+              (when (fboundp 'nskk-inline-show-registration-badge)
+                (nskk-inline-show-registration-badge))
+              (let ((entry (nskk--read-registration-entry reading)))
+                (when entry
+                  (setq result entry)
+                  (nskk--commit-registration-word reading entry))))
+          (cl-decf nskk--registration-depth)
+          (when (fboundp 'nskk-inline-hide)
+            (nskk-inline-hide))
+          (nskk-with-current-state
+            (nskk-state-force-henkan-phase nskk-current-state prev-phase)))
+        (funcall on-found result))
+    (funcall on-found nil)))
+
+(put 'nskk--run-registration-session/k 'nskk--cps-continuation-pattern :found-not-found)
 
 (defun/k nskk-start-registration (reading)
   "Start dictionary registration for READING.
 Opens a minibuffer prompt for the user to enter the desired text.
 READING is the headword that could not be converted.
 Supports recursive registration up to `nskk-max-registration-depth' levels:
-depth 1 shows [辞書登録], depth 2 shows [[辞書登録]], etc.
-Returns the registered word on success, or nil if the user cancels
-or if the maximum nesting depth has been reached."
+depth 1 shows [辞書登録], depth 2 shows [[辞書登録]], etc."
   (nskk-debug-log "[HENKAN] start-registration: reading=%s" reading)
-  ;; Normalize: succeed with nil when cancelled (empty string), so
-  ;; callbacks can use `(if registered ...)' without treating "" as success.
-  (let* ((result     (nskk--run-registration-session reading))
-         (normalized (and (stringp result) (not (string-empty-p result)) result)))
-    (succeed normalized)))
+  (<- result nskk--run-registration-session reading)
+  (succeed result))
 
 (defun nskk--wrap-to-first-candidate ()
   "Reset candidate display to the first page.
@@ -1696,7 +1692,7 @@ If the user cancels, wrap around to the first candidate in list display."
               (if registered
                   (progn
                     (nskk-delete-overlay nskk--conversion-overlay)
-                    (nskk--insert-registered-and-reset registered start (lambda ()) reading))
+                    (nskk--insert-registered-and-reset registered start #'ignore reading))
                 ;; Registration cancelled: wrap back to first candidate page.
                 (nskk--wrap-to-first-candidate)))
             #'ignore))

--- a/test/e2e/nskk-registration-e2e-test.el
+++ b/test/e2e/nskk-registration-e2e-test.el
@@ -373,6 +373,65 @@
             t)
         (error t))))
 
+;;;;
+;;;; Section 8: C-g cancellation tests
+;;;;
+
+(defconst nskk-e2e--reg-7cands-dict
+  '(("かんじ" . ("漢字" "感じ" "幹事" "換字" "貫地" "刊事" "肝事")))
+  "Seven-candidate dict for C-g exhaust-candidates registration tests.")
+
+(nskk-describe "C-g cancellation in registration"
+  (nskk-it "cancels registration on C-g and preserves preedit (no-candidates path)"
+    ;; No candidates on SPC → registration opens → C-g thrown as quit signal
+    ;; → condition-case catches quit → nil returned → on-found called with nil
+    ;; → preedit ▽しんき preserved, phase restored to 'on.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (cl-letf (((symbol-function 'read-from-minibuffer)
+                 (lambda (&rest _) (signal 'quit nil))))
+        (nskk-e2e-type "Shinki")
+        (nskk-e2e-type "SPC")
+        (nskk-e2e-assert-buffer "▽しんき" "Preedit should be preserved after C-g cancel")
+        (nskk-e2e-assert-henkan-phase 'on "Phase should be restored to 'on after C-g")
+        (nskk-e2e-assert-not-converting))))
+
+  (nskk-it "C-g from registration does not leak registration depth"
+    ;; Without condition-case, quit escapes nskk--run-registration-session/k
+    ;; and propagates through the CPS call stack.  Although unwind-protect
+    ;; does decrement the depth counter on non-local exits, the quit signal
+    ;; still unwinds past the on-not-found continuations, leaving nskk in
+    ;; an inconsistent state.  condition-case absorbs quit so the function
+    ;; returns nil normally, letting the CPS callers handle cancellation.
+    (nskk-e2e-with-buffer 'hiragana nil
+      (cl-letf (((symbol-function 'read-from-minibuffer)
+                 (lambda (&rest _) (signal 'quit nil))))
+        (let ((depth-before nskk--registration-depth))
+          (nskk-e2e-type "Shinki")
+          (nskk-e2e-type "SPC")
+          (should (= nskk--registration-depth depth-before))))))
+
+  (nskk-it "C-g during exhaust-candidates wraps to first candidate"
+    ;; Cycle through all 7 candidates (SPC x5 → list, SPC x6 → exhaust).
+    ;; Mock throws quit → condition-case catches it → nil returned
+    ;; → nskk--wrap-to-first-candidate called → phase remains 'list at index 0.
+    ;; 'a' in list phase commits page position 0 = index 0 = 漢字.
+    (nskk-e2e-with-buffer 'hiragana nskk-e2e--reg-7cands-dict
+      (cl-letf (((symbol-function 'read-from-minibuffer)
+                 (lambda (&rest _) (signal 'quit nil))))
+        (nskk-e2e-type "Kanji")
+        (nskk-e2e-type "SPC")   ; SPC#1: start-conversion
+        (nskk-e2e-type "SPC")   ; SPC#2: select-next
+        (nskk-e2e-type "SPC")   ; SPC#3: select-next
+        (nskk-e2e-type "SPC")   ; SPC#4: select-next
+        (nskk-e2e-type "SPC")   ; SPC#5: show-list-next → 'list
+        (nskk-e2e-assert-henkan-phase 'list "Precondition: must be in list phase")
+        (nskk-e2e-type "SPC")   ; SPC#6: exhaust → C-g caught → wrap to index 0
+        (nskk-e2e-assert-henkan-phase 'list "After C-g exhaust: phase must remain 'list")
+        (should nskk--henkan-candidate-list-active)
+        ;; 'a' selects page position 0 = index 0 = 漢字
+        (nskk-e2e-type "a")
+        (nskk-e2e-assert-buffer "漢字" "After C-g cancel wrap, 'a' must commit 漢字")))))
+
 (provide 'nskk-registration-e2e-test)
 
 ;;; nskk-registration-e2e-test.el ends here

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -3621,27 +3621,39 @@
 ;;; nskk--run-registration-session Tests
 ;;;
 
-(nskk-describe "nskk--run-registration-session"
-  (nskk-it "returns nil when depth is at maximum"
+(nskk-describe "nskk--run-registration-session/k"
+  (nskk-it "calls on-found with nil when depth is at maximum"
     (let ((nskk-current-state (nskk-state-create 'hiragana))
-          (nskk--registration-depth 3))
-      (should-not (nskk--run-registration-session "てすと"))))
+          (nskk--registration-depth nskk-max-registration-depth)
+          (result 'unset))
+      (nskk--run-registration-session/k "てすと"
+        (lambda (r) (setq result r))
+        #'ignore)
+      (should-not result)))
 
-  (nskk-it "returns nil when user enters empty string"
+  (nskk-it "calls on-found with nil when user enters empty string"
     (let ((nskk-current-state (nskk-state-create 'hiragana))
-          (nskk--registration-depth 0))
+          (nskk--registration-depth 0)
+          (result 'unset))
       (nskk-state-force-henkan-phase nskk-current-state 'on)
       (nskk-with-mocks ((read-from-minibuffer (lambda (_p) ""))
                         (nskk-dict-register-word #'ignore))
-        (should-not (nskk--run-registration-session "てすと")))))
+        (nskk--run-registration-session/k "てすと"
+          (lambda (r) (setq result r))
+          (lambda () (error "on-not-found must not be called"))))
+      (should-not result)))
 
-  (nskk-it "returns the entered word when user provides input"
+  (nskk-it "calls on-found with the entered word when user provides input"
     (let ((nskk-current-state (nskk-state-create 'hiragana))
-          (nskk--registration-depth 0))
+          (nskk--registration-depth 0)
+          (result nil))
       (nskk-state-force-henkan-phase nskk-current-state 'on)
       (nskk-with-mocks ((read-from-minibuffer (lambda (_p) "漢字"))
                         (nskk-dict-register-word #'ignore))
-        (should (equal (nskk--run-registration-session "かんじ") "漢字")))))
+        (nskk--run-registration-session/k "かんじ"
+          (lambda (r) (setq result r))
+          (lambda () (error "on-not-found must not be called"))))
+      (should (equal result "漢字"))))
 
   (nskk-it "increments and decrements depth atomically"
     (let ((nskk-current-state (nskk-state-create 'hiragana))
@@ -3651,9 +3663,44 @@
       (nskk-with-mocks ((read-from-minibuffer
                          (lambda (_p) (setq depth-during nskk--registration-depth) ""))
                         (nskk-dict-register-word #'ignore))
-        (nskk--run-registration-session "てすと"))
+        (nskk--run-registration-session/k "てすと"
+          (lambda (_r) nil)
+          (lambda () (error "on-not-found must not be called"))))
       (should (= depth-during 1))
+      (should (= nskk--registration-depth 0))))
+
+  (nskk-it "calls on-found with nil and restores depth on C-g (quit signal)"
+    (let ((nskk-current-state (nskk-state-create 'hiragana))
+          (nskk--registration-depth 0)
+          (result 'unset))
+      (nskk-state-force-henkan-phase nskk-current-state 'on)
+      (nskk-with-mocks ((read-from-minibuffer (lambda (_p) (signal 'quit nil)))
+                        (nskk-dict-register-word #'ignore))
+        (nskk--run-registration-session/k "てすと"
+          (lambda (r) (setq result r))
+          (lambda () (error "on-not-found must not be called"))))
+      (should (null result))
       (should (= nskk--registration-depth 0)))))
+
+;;;
+;;; nskk--read-registration-entry Tests
+;;;
+
+(nskk-describe "nskk--read-registration-entry"
+  (nskk-it "returns nil on C-g (quit signal)"
+    (let ((nskk--registration-depth 0))
+      (nskk-with-mocks ((read-from-minibuffer (lambda (_p) (signal 'quit nil))))
+        (should-not (nskk--read-registration-entry "てすと")))))
+
+  (nskk-it "returns nil on empty string"
+    (let ((nskk--registration-depth 0))
+      (nskk-with-mocks ((read-from-minibuffer (lambda (_p) "")))
+        (should-not (nskk--read-registration-entry "てすと")))))
+
+  (nskk-it "returns entry string when user provides input"
+    (let ((nskk--registration-depth 0))
+      (nskk-with-mocks ((read-from-minibuffer (lambda (_p) "漢字")))
+        (should (equal (nskk--read-registration-entry "かんじ") "漢字"))))))
 
 ;;;
 ;;; search-backend/2 Prolog Facts Tests


### PR DESCRIPTION
## Summary

Fixes #38: C-g (keyboard-quit) in the `[辞書登録]` minibuffer now correctly cancels registration and returns to `▽` preedit state, matching DDSKK behavior.

- **C-g fix**: `condition-case nil ... (quit nil)` wraps `read-from-minibuffer` inside `nskk--read-registration-entry`, absorbing the quit signal before it can propagate through the CPS call stack and leave conversion state inconsistent
- **CPS conversion**: `nskk--run-registration-session` renamed to `nskk--run-registration-session/k` (hand-written CPS pair following the `nskk--debug-format/k` pattern); `nskk-start-registration` uses the `<-` bind operator
- **Refactor**: extracted `nskk--read-registration-entry-with-kana`, `nskk--read-registration-entry`, and `nskk--commit-registration-word`, reducing `nskk--run-registration-session/k` body from ~90 to ~25 lines
- **Resource safety**: `nskk-inline-show-registration-badge` moved inside `unwind-protect` body to prevent depth counter leak on error
- **Tests**: +3 E2E tests (C-g preserves preedit, depth not leaked, exhaust+C-g wraps to first candidate), +8 unit tests (CPS interface, C-g unit path, `nskk--read-registration-entry` helpers); 5618/5618 passing

## Test plan

- [x] `make compile` — zero warnings
- [x] `make test` — 5618/5618 passing
- [x] Manual tests via emacs daemon: 10/10 scenarios pass
  - C-g during no-candidates registration preserves `▽` preedit
  - C-g does not leak `nskk--registration-depth`
  - Exhausting candidates then C-g wraps to first candidate (`漢字`)
  - Normal registration still commits word to dictionary
  - Max depth guard still returns nil to `on-found`