### PR TITLE
fix: delegate RET to next binding in normal state for completion UI compatibility

### DIFF
--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -652,12 +652,20 @@ modes insert a literal ASCII space."
 In conversion mode, commits the selected candidate without inserting
 a newline.  In preedit (▽) mode, commits the raw kana reading via
 `nskk-henkan-kakutei' then inserts a newline (matching DDSKK behavior).
-In normal mode, inserts a newline unconditionally."
+In normal mode, delegates to the next RET binding (skipping nskk-mode-map),
+falling back to `newline' if no other binding is found.  This matches the
+behavior of `nskk-handle-tab' and ensures compatibility with completion UIs
+such as corfu."
   ('commit-candidate (nskk-commit-current))
   ('kakutei-and-newline
    (nskk-henkan-kakutei)
    (newline))
-  (_ (newline)))
+  (_ (let ((cmd (let ((nskk-mode nil))
+                  (key-binding "\r"))))
+       (cond
+        ((or (stringp cmd) (vectorp cmd)) (execute-kbd-macro cmd))
+        ((commandp cmd) (call-interactively cmd))
+        (t (newline))))))
 
 (defmacro nskk-define-nav-handler (key docstring kakutei-action nav-action nav-cmd &optional error-type)
   "Define a commit-then-navigate handler for KEY.
@@ -820,9 +828,10 @@ when no major-mode binding exists."
                        (nskk-dynamic-complete)))
   (_ (let ((cmd (let ((nskk-mode nil))
                   (key-binding "\t"))))
-       (if (commandp cmd)
-           (call-interactively cmd)
-         (indent-for-tab-command)))))
+       (cond
+        ((or (stringp cmd) (vectorp cmd)) (execute-kbd-macro cmd))
+        ((commandp cmd) (call-interactively cmd))
+        (t (indent-for-tab-command))))))
 
 (nskk-define-mode-switch-handler hash
   "Handle # key: enter numeric input mode in Japanese mode.

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -606,7 +606,49 @@ NAV-FN is the fallthrough navigation command symbol (e.g. `forward-char')."
           (nskk-when (nskk-handle-return))
           (nskk-then
            (should kakutei-called)
-           (should newline-called)))))))
+           (should newline-called))))))
+
+  (nskk-context "fall-through in normal state"
+    (nskk-it "delegates to local RET binding when nskk-mode is active (corfu-style passthrough)"
+      ;; When nskk-mode is active, `nskk-handle-return' in normal state should
+      ;; look up RET with nskk-mode nil — skipping nskk-mode-map — and call the
+      ;; next available binding (e.g. a completion UI's confirm action).
+      (with-temp-buffer
+        (nskk-mode 1)
+        (unwind-protect
+            (let ((passthrough-called nil))
+              (local-set-key (kbd "RET")
+                             (lambda () (interactive) (setq passthrough-called t)))
+              (let ((nskk-current-state (nskk-state-create 'hiragana)))
+                (call-interactively 'nskk-handle-return))
+              (should passthrough-called))
+          (nskk-mode -1))))
+
+    (nskk-it "falls back to newline when key-binding returns nil in normal state"
+      ;; If no other RET binding exists (key-binding returns nil), the handler
+      ;; falls back to `newline' rather than silently doing nothing.
+      (with-temp-buffer
+        (let ((newline-called nil))
+          (nskk-with-mocks ((key-binding (lambda (_key) nil))
+                            (newline     (lambda () (setq newline-called t))))
+            (let ((nskk-current-state (nskk-state-create 'hiragana)))
+              (call-interactively 'nskk-handle-return)))
+          (should newline-called))))
+
+    (nskk-it "does not raise wrong-type-argument for keyboard-macro RET bindings"
+      ;; `commandp' returns t for strings/vectors (keyboard macros), but in
+      ;; some Emacs versions `call-interactively' raises wrong-type-argument
+      ;; for them.  The handler must dispatch string/vector cmd through
+      ;; `execute-kbd-macro', not `call-interactively'.
+      (with-temp-buffer
+        (let ((error-raised nil))
+          (condition-case _err
+              (nskk-with-mocks ((key-binding       (lambda (_key) "test"))
+                                (execute-kbd-macro (lambda (&rest _) nil)))
+                (let ((nskk-current-state (nskk-state-create 'hiragana)))
+                  (call-interactively 'nskk-handle-return)))
+            (wrong-type-argument (setq error-raised t)))
+          (should-not error-raised))))))
 
 ;;;
 ;;; nskk-handle-cancel behavior


### PR DESCRIPTION
## Summary

- `nskk-handle-return` in normal state previously hardcoded `(newline)`, causing completion UIs (corfu, consult) to insert a newline instead of confirming the selection when `nskk-mode` was active (fixes #40)
- Now uses `(let ((nskk-mode nil)) (key-binding "\r"))` to look up the next RET binding while skipping `nskk-mode-map`, then dispatches: string/vector → `execute-kbd-macro`, commandp → `call-interactively`, else → `newline` fallback
- Mirrors the existing `nskk-handle-tab` fall-through pattern; this is the fundamental fix rather than a workaround

## Test plan

- [ ] 3 new unit tests in `nskk-keymap-test.el`: corfu-style local binding passthrough, nil fallback to newline, keyboard-macro dispatch safety
- [ ] Full suite: 5621/5621 passing
- [ ] Verified live against running Emacs with corfu+cape: transient map (popup active) → `corfu-insert`; no popup → `newline`