### PR TITLE
feat: AZIK ch/sh/th vowel-shadow continuation in conversion mode

### DIFF
--- a/nskk-input.el
+++ b/nskk-input.el
@@ -154,15 +154,73 @@ See also `nskk--deferred-vowel-shadow-state' for the vowel-shadow variant.")
 
 (defvar-local nskk--deferred-vowel-shadow-state nil
   "Non-nil when a vowel-shadowed AZIK rule was tentatively emitted.
-Value is a cons (ROMAJI-STRING . KANA-STRING).  ROMAJI-STRING is the romaji
-prefix (e.g. \"sh\") and KANA-STRING is the tentatively emitted kana
-\(e.g. \"すう\").  On the next input:
+Value is a `nskk--deferred-vowel-shadow' payload carrying the romaji prefix,
+tentative kana, and an optional continuation policy.  On the next input:
   - Vowel: delete tentative kana, reset romaji buffer to ROMAJI-STRING, then
     process ROMAJI-STRING+vowel as the longer standard rule
     (e.g. \"sha\"→\"しゃ\").
     Unlike `nskk--deferred-azik-state', NO っ is inserted.
   - Non-vowel: clear deferred state without retroactive correction.
 Satisfies Sh→すう (AZIK double-vowel) while preserving sha→しゃ (standard romaji).")
+
+(cl-defstruct (nskk--deferred-vowel-shadow
+                (:constructor nskk--make-deferred-vowel-shadow
+                              (romaji kana &optional continuation-policy)))
+   "Deferred vowel-shadow payload: ROMAJI (string) for retroactive restart,
+KANA (string) that was tentatively emitted, and optional CONTINUATION-POLICY
+(determines whether uppercase vowels continue the deferred reading).
+Stored in `nskk--deferred-vowel-shadow-state' when a vowel-shadowed AZIK
+rule was tentatively emitted."
+  romaji kana continuation-policy)
+
+(defconst nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy
+  'uppercase-vowel-continue
+  "Continuation policy that treats an uppercase vowel as reading continuation.")
+
+(defun nskk--deferred-vowel-shadow-policy-for-input (input)
+  "Return the deferred vowel-shadow continuation policy for INPUT.
+This MVP enables uppercase-vowel continuation only for `ch', `sh', and `th'."
+  (and (member input '("ch" "sh" "th"))
+       nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy))
+
+(defun nskk--deferred-state-key (state)
+  "Return the deferred correction key stored in STATE."
+  (cond
+   ((nskk--deferred-vowel-shadow-p state)
+    (nskk--deferred-vowel-shadow-romaji state))
+   ((consp state) (car state))
+   (t nil)))
+
+(defun nskk--deferred-state-kana (state)
+  "Return the tentative kana string stored in STATE."
+  (cond
+   ((nskk--deferred-vowel-shadow-p state)
+    (nskk--deferred-vowel-shadow-kana state))
+   ((consp state) (cdr state))
+   (t nil)))
+
+(defun nskk--deferred-vowel-shadow-uppercase-continuation-p (char)
+  "Return non-nil when CHAR should continue the deferred vowel-shadow reading."
+  (let ((state nskk--deferred-vowel-shadow-state))
+    (and (nskk--deferred-vowel-shadow-p state)
+         (eq (nskk--deferred-vowel-shadow-continuation-policy state)
+             nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy)
+         (characterp char)
+         (nskk-prolog-holds-p `(uppercase-vowel-char ,char)))))
+
+(defun nskk--downcase-normal-japanese-effective-char (effective-char normalize-vowel-p
+                                                                     continue-vowel-shadow-p)
+  "Return EFFECTIVE-CHAR adjusted for normal Japanese input handling.
+Uppercase chars are downcased only when okurigana is pending or when
+CONTINUE-VOWEL-SHADOW-P keeps an explicit deferred reading alive."
+  (if (and (not normalize-vowel-p)
+           (characterp effective-char)
+           (<= ?A effective-char) (<= effective-char ?Z)
+           (or (nskk-with-current-state
+                 (nskk-state-get-okurigana nskk-current-state))
+               continue-vowel-shadow-p))
+      (downcase effective-char)
+    effective-char))
 
 (defun nskk--azik-colon-key-p (char)
   "Return non-nil when CHAR arms the AZIK colon-okurigana pending state.
@@ -723,24 +781,24 @@ through okurigana processing or delegates to the romaji-to-kana converter.
 Called from `nskk-process-japanese-input' for the `normal' action class."
   (cl-destructuring-bind (effective-char is-henkan-start normalize-vowel-p)
       (nskk--compute-effective-char char)
-    (when is-henkan-start
-      (nskk--setup-henkan-start-marker char))
-    (if (and (not is-henkan-start)
-             (not normalize-vowel-p)
-             (nskk-process-okurigana-input char))
-        (nskk-debug-log "[INPUT] okurigana-processed: char=%c" char)
-      ;; When okurigana is pending but re-entry was blocked (e.g. second N
-      ;; in YoNN), downcase uppercase chars so the romaji converter sees
-      ;; "nn" instead of "nN".
-      (let ((eff (if (and (not normalize-vowel-p)
-                          (characterp effective-char)
-                          (<= ?A effective-char) (<= effective-char ?Z)
-                          (nskk-with-current-state
-                            (nskk-state-get-okurigana nskk-current-state)))
-                     (downcase effective-char)
-                   effective-char)))
-        (nskk--process-kana-result
-         (or (nskk-convert-input-to-kana eff) "") n)))))
+    (let ((continue-vowel-shadow-p
+           (nskk--deferred-vowel-shadow-uppercase-continuation-p char)))
+      (when is-henkan-start
+        (nskk--setup-henkan-start-marker char))
+      (if (and (not is-henkan-start)
+               (not normalize-vowel-p)
+               (not continue-vowel-shadow-p)
+               (nskk-process-okurigana-input char))
+          (nskk-debug-log "[INPUT] okurigana-processed: char=%c" char)
+        ;; When okurigana is pending but re-entry was blocked (e.g. second N
+        ;; in YoNN), downcase uppercase chars so the romaji converter sees
+        ;; "nn" instead of "nN".
+        (let ((eff (nskk--downcase-normal-japanese-effective-char
+                    effective-char normalize-vowel-p continue-vowel-shadow-p)))
+          (when continue-vowel-shadow-p
+            (setq nskk--deferred-vowel-shadow-state nil))
+          (nskk--process-kana-result
+           (or (nskk-convert-input-to-kana eff) "") n))))))
 
 (defun/done nskk-process-japanese-input (char n)
   "Process input in Japanese mode (hiragana/katakana), then call on-done.
@@ -990,16 +1048,18 @@ Each is a no-op when its respective deferred-state variable is nil."
 (defun nskk--apply-one-deferred-correction (state-var char insert-sokuon-p)
   "Apply one deferred correction for CHAR using STATE-VAR.
 STATE-VAR is a symbol naming a buffer-local variable holding
-\(KEY . KANA) or nil.
+either a deferred payload (e.g., `nskk--deferred-azik-state' or
+`nskk--deferred-vowel-shadow-state') or nil.
 When CHAR is a vowel and STATE-VAR is set: deletes the tentative kana,
 optionally inserts っ (when INSERT-SOKUON-P is non-nil), and resets
-`nskk--romaji-buffer' to the key portion of the deferred state.
+`nskk--romaji-buffer' to the key portion of the deferred state (for retroactive
+processing with the vowel).
 KEY can be a character (via `char-to-string') or a string (used as-is).
 A non-vowel CHAR clears the state without correction."
   (let ((state (symbol-value state-var)))
     (when state
-      (let ((deferred-key (car state))
-            (deferred-kana (cdr state)))
+      (let ((deferred-key (nskk--deferred-state-key state))
+            (deferred-kana (nskk--deferred-state-kana state)))
         (set state-var nil)
         (when (nskk-prolog-holds-p `(vowel-char ,char))
           (delete-char (- (length deferred-kana)))
@@ -1059,7 +1119,10 @@ this emission and process INPUT+vowel as the longer standard-romaji rule
   (let ((kana (car result)))
     (nskk-debug-log "[INPUT] azik-vowel-deferred-emit: input=%s kana=%s" input kana)
     (setq nskk--deferred-azik-state nil)
-    (setq nskk--deferred-vowel-shadow-state (cons input kana))
+    (setq nskk--deferred-vowel-shadow-state
+          (nskk--make-deferred-vowel-shadow
+           input kana
+           (nskk--deferred-vowel-shadow-policy-for-input input)))
     (setq nskk--romaji-buffer "")
     (succeed kana)))
 

--- a/nskk-input.el
+++ b/nskk-input.el
@@ -154,15 +154,91 @@ See also `nskk--deferred-vowel-shadow-state' for the vowel-shadow variant.")
 
 (defvar-local nskk--deferred-vowel-shadow-state nil
   "Non-nil when a vowel-shadowed AZIK rule was tentatively emitted.
-Value is a cons (ROMAJI-STRING . KANA-STRING).  ROMAJI-STRING is the romaji
-prefix (e.g. \"sh\") and KANA-STRING is the tentatively emitted kana
-\(e.g. \"すう\").  On the next input:
+Value is a `nskk--deferred-vowel-shadow' payload carrying the romaji prefix,
+tentative kana, and an optional continuation policy.  On the next input:
   - Vowel: delete tentative kana, reset romaji buffer to ROMAJI-STRING, then
     process ROMAJI-STRING+vowel as the longer standard rule
     (e.g. \"sha\"→\"しゃ\").
     Unlike `nskk--deferred-azik-state', NO っ is inserted.
   - Non-vowel: clear deferred state without retroactive correction.
 Satisfies Sh→すう (AZIK double-vowel) while preserving sha→しゃ (standard romaji).")
+
+(cl-defstruct (nskk--deferred-vowel-shadow
+                (:constructor nskk--make-deferred-vowel-shadow
+                              (romaji kana &optional continuation-policy)))
+   "Deferred vowel-shadow payload: ROMAJI (string) for retroactive restart,
+KANA (string) that was tentatively emitted, and optional CONTINUATION-POLICY
+(determines whether uppercase vowels continue the deferred reading).
+Stored in `nskk--deferred-vowel-shadow-state' when a vowel-shadowed AZIK
+rule was tentatively emitted."
+  romaji kana continuation-policy)
+
+(defconst nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy
+  'uppercase-vowel-continue
+  "Continuation policy that treats an uppercase vowel as reading continuation.")
+
+(defun nskk--deferred-vowel-shadow-policy-for-input (input)
+  "Return the deferred vowel-shadow continuation policy for INPUT.
+Returns `nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy' for
+`ch', `sh', and `th' — the three standard AZIK h-extension prefixes that
+users commonly encounter in conversion readings (ちゅう, すう, つう).
+Other vowel-shadow keys (e.g. `kh'→きゅう, `nh'→にゅう) are intentionally
+excluded: their uppercase-vowel continuations are rare enough that the
+standard correction (kho→きょ) is more often the intended input."
+  (and (member input '("ch" "sh" "th"))
+       nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy))
+
+(defun nskk--deferred-state-key (state)
+  "Return the deferred correction key stored in STATE.
+Handles both `nskk--deferred-vowel-shadow' structs (DV path)
+and bare cons cells `(key . kana)' (DA sokuon path)."
+  (cond
+   ((nskk--deferred-vowel-shadow-p state)
+    (nskk--deferred-vowel-shadow-romaji state))
+   ((consp state) (car state))
+   (t nil)))
+
+(defun nskk--deferred-state-kana (state)
+  "Return the tentative kana string stored in STATE.
+Handles both `nskk--deferred-vowel-shadow' structs (DV path)
+and bare cons cells `(key . kana)' (DA sokuon path)."
+  (cond
+   ((nskk--deferred-vowel-shadow-p state)
+    (nskk--deferred-vowel-shadow-kana state))
+   ((consp state) (cdr state))
+   (t nil)))
+
+(defun nskk--deferred-vowel-shadow-uppercase-continuation-p (char)
+  "Return non-nil when CHAR should continue the deferred vowel-shadow reading.
+Continuation fires when the DV state carries `uppercase-vowel-continue' policy
+AND CHAR is either:
+  - An uppercase vowel (A/I/U/E/O) in any mode, OR
+  - A lowercase vowel (a/i/u/e/o) while conversion mode (▽) is active.
+The lowercase case lets `Cho' accumulate ちゅうお as a conversion reading
+instead of firing the AZIK correction (cho→ちょ), while preserving the
+correction for plain hiragana input where no ▽ is open."
+  (let ((state nskk--deferred-vowel-shadow-state))
+    (and (nskk--deferred-vowel-shadow-p state)
+         (eq (nskk--deferred-vowel-shadow-continuation-policy state)
+             nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy)
+         (characterp char)
+         (or (nskk-prolog-holds-p `(uppercase-vowel-char ,char))
+             (and (nskk--conversion-start-active-p)
+                  (nskk-prolog-holds-p `(vowel-char ,char)))))))
+
+(defun nskk--downcase-normal-japanese-effective-char (effective-char normalize-vowel-p
+                                                                     continue-vowel-shadow-p)
+  "Return EFFECTIVE-CHAR adjusted for normal Japanese input handling.
+Uppercase chars are downcased only when okurigana is pending or when
+CONTINUE-VOWEL-SHADOW-P keeps an explicit deferred reading alive."
+  (if (and (not normalize-vowel-p)
+           (characterp effective-char)
+           (<= ?A effective-char) (<= effective-char ?Z)
+           (or (nskk-with-current-state
+                 (nskk-state-get-okurigana nskk-current-state))
+               continue-vowel-shadow-p))
+      (downcase effective-char)
+    effective-char))
 
 (defun nskk--azik-colon-key-p (char)
   "Return non-nil when CHAR arms the AZIK colon-okurigana pending state.
@@ -723,24 +799,29 @@ through okurigana processing or delegates to the romaji-to-kana converter.
 Called from `nskk-process-japanese-input' for the `normal' action class."
   (cl-destructuring-bind (effective-char is-henkan-start normalize-vowel-p)
       (nskk--compute-effective-char char)
-    (when is-henkan-start
-      (nskk--setup-henkan-start-marker char))
-    (if (and (not is-henkan-start)
-             (not normalize-vowel-p)
-             (nskk-process-okurigana-input char))
-        (nskk-debug-log "[INPUT] okurigana-processed: char=%c" char)
-      ;; When okurigana is pending but re-entry was blocked (e.g. second N
-      ;; in YoNN), downcase uppercase chars so the romaji converter sees
-      ;; "nn" instead of "nN".
-      (let ((eff (if (and (not normalize-vowel-p)
-                          (characterp effective-char)
-                          (<= ?A effective-char) (<= effective-char ?Z)
-                          (nskk-with-current-state
-                            (nskk-state-get-okurigana nskk-current-state)))
-                     (downcase effective-char)
-                   effective-char)))
-        (nskk--process-kana-result
-         (or (nskk-convert-input-to-kana eff) "") n)))))
+    (let ((continue-vowel-shadow-p
+           (nskk--deferred-vowel-shadow-uppercase-continuation-p char)))
+      (when is-henkan-start
+        (nskk--setup-henkan-start-marker char))
+      ;; Uppercase vowel continuation bypasses okurigana: the DV state and
+      ;; okurigana cannot both be active simultaneously (DV is cleared at every
+      ;; kakutei/cancel boundary that also resets okurigana state).
+      (if (and (not is-henkan-start)
+               (not normalize-vowel-p)
+               (not continue-vowel-shadow-p)
+               (nskk-process-okurigana-input char))
+          (nskk-debug-log "[INPUT] okurigana-processed: char=%c" char)
+        ;; When okurigana is pending but re-entry was blocked (e.g. second N
+        ;; in YoNN), downcase uppercase chars so the romaji converter sees
+        ;; "nn" instead of "nN".
+        (let ((eff (nskk--downcase-normal-japanese-effective-char
+                    effective-char normalize-vowel-p continue-vowel-shadow-p)))
+          ;; Clear DV state before convert so nskk--apply-vowel-shadow-correction
+          ;; does not retroactively replace the tentative kana.
+          (when continue-vowel-shadow-p
+            (setq nskk--deferred-vowel-shadow-state nil))
+          (nskk--process-kana-result
+           (or (nskk-convert-input-to-kana eff) "") n))))))
 
 (defun/done nskk-process-japanese-input (char n)
   "Process input in Japanese mode (hiragana/katakana), then call on-done.
@@ -990,16 +1071,18 @@ Each is a no-op when its respective deferred-state variable is nil."
 (defun nskk--apply-one-deferred-correction (state-var char insert-sokuon-p)
   "Apply one deferred correction for CHAR using STATE-VAR.
 STATE-VAR is a symbol naming a buffer-local variable holding
-\(KEY . KANA) or nil.
+either a deferred payload (e.g., `nskk--deferred-azik-state' or
+`nskk--deferred-vowel-shadow-state') or nil.
 When CHAR is a vowel and STATE-VAR is set: deletes the tentative kana,
 optionally inserts っ (when INSERT-SOKUON-P is non-nil), and resets
-`nskk--romaji-buffer' to the key portion of the deferred state.
+`nskk--romaji-buffer' to the key portion of the deferred state (for retroactive
+processing with the vowel).
 KEY can be a character (via `char-to-string') or a string (used as-is).
 A non-vowel CHAR clears the state without correction."
   (let ((state (symbol-value state-var)))
     (when state
-      (let ((deferred-key (car state))
-            (deferred-kana (cdr state)))
+      (let ((deferred-key (nskk--deferred-state-key state))
+            (deferred-kana (nskk--deferred-state-kana state)))
         (set state-var nil)
         (when (nskk-prolog-holds-p `(vowel-char ,char))
           (delete-char (- (length deferred-kana)))
@@ -1059,7 +1142,10 @@ this emission and process INPUT+vowel as the longer standard-romaji rule
   (let ((kana (car result)))
     (nskk-debug-log "[INPUT] azik-vowel-deferred-emit: input=%s kana=%s" input kana)
     (setq nskk--deferred-azik-state nil)
-    (setq nskk--deferred-vowel-shadow-state (cons input kana))
+    (setq nskk--deferred-vowel-shadow-state
+          (nskk--make-deferred-vowel-shadow
+           input kana
+           (nskk--deferred-vowel-shadow-policy-for-input input)))
     (setq nskk--romaji-buffer "")
     (succeed kana)))
 

--- a/nskk-keymap.el
+++ b/nskk-keymap.el
@@ -109,6 +109,7 @@
 (declare-function nskk-handle-q-key "nskk-input")
 (declare-function nskk--azik-complete-match-p "nskk-input")
 (declare-function nskk--romaji-has-match-p "nskk-input")
+(declare-function nskk--deferred-state-kana "nskk-input" (state))
 (declare-function nskk-process-japanese-input "nskk-input")
 (declare-function nskk-set-mode-numeric "nskk-input")
 (declare-function nskk--try-candidate-selection/k "nskk-input" (char on-found on-not-found))
@@ -198,13 +199,15 @@
 
 ;;;; L-Key Dispatch Rules
 
-;; l-key-action/3: AZIK-aware dispatch for the l key.
+;; l-key-action/3: Dispatch for the l key, shared by all romaji styles.
 ;; (l-key-action STYLE BUF-STATE ACTION)
 ;; STYLE is `azik' or `standard' (from nskk-converter-romaji-style).
 ;; BUF-STATE is `azik-complete' when pending-romaji+l forms a complete rule
-;; match (AZIK hash or standard romaji rule); `other' otherwise.  Both styles
-;; map `azik-complete' to fire-romaji (e.g. "zl" -> "->" in standard mode) and
-;; `other' to latin-mode.
+;; match (checked by `nskk--azik-complete-match-p' or
+;; `nskk--romaji-has-match-p'); `other' otherwise.  Despite the historical
+;; name, `azik-complete' is a style-neutral "complete-match" label: both
+;; styles map it to `fire-romaji' (e.g. "zl" -> "→" in standard mode) and
+;; `other' to `latin-mode'.
 (nskk-prolog-define-fact-table l-key-action (:arity 3 :index :hash)
   (azik     azik-complete fire-romaji)
   (azik     other         latin-mode)
@@ -569,7 +572,9 @@ Dispatched via `q-key-dispatch/3' Prolog table."
 
 (defun/done nskk--handle-l-action ()
   "Helper for `nskk-handle-l' mode-switch and fire-romaji actions.
-Dispatched via `l-key-action/3' Prolog table (style, buf-state, action)."
+Dispatched via `l-key-action/3' Prolog table (style, buf-state, action).
+BUF-STATE uses `azik-complete' as a shared complete-match label for both
+AZIK and standard styles (see `l-key-action/3' table comment)."
   (let* ((style (if (eq nskk-converter-romaji-style 'azik) 'azik 'standard))
          (buf-state (if (or (nskk--azik-complete-match-p ?l)
                             (nskk--romaji-has-match-p ?l))
@@ -757,7 +762,8 @@ Caller is responsible for preedit boundary checks after retraction."
    ;; 2. DV: deferred-vowel-shadow-state -- delete tentative kana
    ((and (boundp 'nskk--deferred-vowel-shadow-state)
          nskk--deferred-vowel-shadow-state)
-    (delete-char (- (length (cdr nskk--deferred-vowel-shadow-state))))
+    (delete-char (- (length (nskk--deferred-state-kana
+                             nskk--deferred-vowel-shadow-state))))
     (setq nskk--deferred-vowel-shadow-state nil)
     t)
    ;; 3. CP: colon-okuri-pending -- delete `*' marker

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -283,7 +283,101 @@ This ensures:
   (nskk-it "double vowel sequence: kp + ka produces こうか"
     (nskk-e2e-with-azik-buffer 'hiragana nil
       (nskk-e2e-type "kpka")
-      (nskk-e2e-assert-buffer "こうか"))))
+      (nskk-e2e-assert-buffer "こうか")))
+
+  (nskk-it "ChO preserves deferred ちゅう and appends お in AZIK hiragana mode"
+    ;; `ch' carries explicit uppercase-vowel continuation policy, so the
+    ;; deferred reading stays in the normal kana path and ChO -> ちゅうお.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ChO")
+      (nskk-e2e-assert-buffer "▽ちゅうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ChOu produces ちゅうおう in AZIK hiragana mode"
+    ;; The same `ch' continuation policy must preserve the trailing `u'
+    ;; conversion, yielding ChOu -> ちゅうおう.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ChOu")
+      (nskk-e2e-assert-buffer "▽ちゅうおう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ShO preserves deferred すう and appends お in AZIK hiragana mode"
+    ;; `sh' is also policy-enabled, so uppercase-vowel continuation must keep
+    ;; the deferred reading in the kana path and yield ShO -> すうお.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ShO")
+      (nskk-e2e-assert-buffer "▽すうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ShOu produces すうおう in AZIK hiragana mode"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ShOu")
+      (nskk-e2e-assert-buffer "▽すうおう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ThO preserves deferred つう and appends お in AZIK hiragana mode"
+    ;; `th' uses the same policy-driven continuation and should yield つうお.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ThO")
+      (nskk-e2e-assert-buffer "▽つうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ThOu produces つうおう in AZIK hiragana mode"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ThOu")
+      (nskk-e2e-assert-buffer "▽つうおう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  ;; Remaining uppercase vowels: verify A/I/U/E also continue the deferred reading.
+  (nskk-it "ChA continues deferred ちゅう and appends あ"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ChA")
+      (nskk-e2e-assert-buffer "▽ちゅうあ")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ShI continues deferred すう and appends い"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ShI")
+      (nskk-e2e-assert-buffer "▽すうい")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ThU continues deferred つう and appends う"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ThU")
+      (nskk-e2e-assert-buffer "▽つうう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ChE continues deferred ちゅう and appends え"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ChE")
+      (nskk-e2e-assert-buffer "▽ちゅうえ")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  ;; In conversion mode (▽ active), lowercase vowels also continue the deferred
+  ;; reading instead of triggering DV correction.  The user sees ちゅう after
+  ;; typing Ch and expects o to extend it, not replace it with ちょ.
+  (nskk-it "Cho with lowercase o continues deferred ちゅう in conversion mode"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "Cho")
+      (nskk-e2e-assert-buffer "▽ちゅうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "Sha with lowercase a continues deferred すう in conversion mode"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "Sha")
+      (nskk-e2e-assert-buffer "▽すうあ")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  ;; Guard: in plain hiragana (no ▽), DV correction still fires for lowercase.
+  (nskk-it "cho all-lowercase in hiragana mode still gives ちょ via DV correction"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "cho")
+      (nskk-e2e-assert-buffer "ちょ")))
+
+  (nskk-it "sha all-lowercase in hiragana mode still gives しゃ via DV correction"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "sha")
+      (nskk-e2e-assert-buffer "しゃ"))))
 
 ;;;;
 ;;;; Section 5: AZIK Q-Key Behavior — Context-Aware Mode
@@ -1569,7 +1663,22 @@ This ensures:
         (nskk-e2e-type "Kakk")
         (nskk-e2e-type "SPC")
         (nskk-e2e-type "C-g")
-        (should (not (bound-and-true-p nskk--deferred-azik-state)))))))
+        (should (not (bound-and-true-p nskk--deferred-azik-state))))))
+
+  (nskk-it "T-04: nskk--deferred-vowel-shadow-state is nil after rollback-conversion"
+    ;; Regression for FR-001.
+    ;; "Kash" sets DV in preedit; SPC triggers conversion; C-g rolls back.
+    ;; nskk-rollback-conversion calls nskk--clear-azik-pending-state, which
+    ;; must also clear DV so the next vowel does not retroactively rewrite the
+    ;; rolled-back reading.
+    (let ((dict '(("かすう" . ("加数")))))
+      (nskk-e2e-with-azik-buffer 'hiragana dict
+        (nskk-e2e-type "Kash")
+        (nskk-e2e-type "SPC")
+        (nskk-e2e-type "C-g")
+        (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))
+        (nskk-e2e-type "a")
+        (nskk-e2e-assert-buffer "▽かすうあ")))))
 
 ;;;;
 ;;;; Section 19: Output correctness PBT — sokuon via DA correction (P-04)

--- a/test/e2e/nskk-azik-e2e-test.el
+++ b/test/e2e/nskk-azik-e2e-test.el
@@ -283,7 +283,50 @@ This ensures:
   (nskk-it "double vowel sequence: kp + ka produces こうか"
     (nskk-e2e-with-azik-buffer 'hiragana nil
       (nskk-e2e-type "kpka")
-      (nskk-e2e-assert-buffer "こうか"))))
+      (nskk-e2e-assert-buffer "こうか")))
+
+  (nskk-it "ChO preserves deferred ちゅう and appends お in AZIK hiragana mode"
+    ;; `ch' carries explicit uppercase-vowel continuation policy, so the
+    ;; deferred reading stays in the normal kana path and ChO -> ちゅうお.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ChO")
+      (nskk-e2e-assert-buffer "▽ちゅうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ChOu produces ちゅうおう in AZIK hiragana mode"
+    ;; The same `ch' continuation policy must preserve the trailing `u'
+    ;; conversion, yielding ChOu -> ちゅうおう.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ChOu")
+      (nskk-e2e-assert-buffer "▽ちゅうおう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ShO preserves deferred すう and appends お in AZIK hiragana mode"
+    ;; `sh' is also policy-enabled, so uppercase-vowel continuation must keep
+    ;; the deferred reading in the kana path and yield ShO -> すうお.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ShO")
+      (nskk-e2e-assert-buffer "▽すうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ShOu produces すうおう in AZIK hiragana mode"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ShOu")
+      (nskk-e2e-assert-buffer "▽すうおう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ThO preserves deferred つう and appends お in AZIK hiragana mode"
+    ;; `th' uses the same policy-driven continuation and should yield つうお.
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ThO")
+      (nskk-e2e-assert-buffer "▽つうお")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))))
+
+  (nskk-it "ThOu produces つうおう in AZIK hiragana mode"
+    (nskk-e2e-with-azik-buffer 'hiragana nil
+      (nskk-e2e-type "ThOu")
+      (nskk-e2e-assert-buffer "▽つうおう")
+      (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state))))))
 
 ;;;;
 ;;;; Section 5: AZIK Q-Key Behavior — Context-Aware Mode
@@ -1569,7 +1612,22 @@ This ensures:
         (nskk-e2e-type "Kakk")
         (nskk-e2e-type "SPC")
         (nskk-e2e-type "C-g")
-        (should (not (bound-and-true-p nskk--deferred-azik-state)))))))
+        (should (not (bound-and-true-p nskk--deferred-azik-state))))))
+
+  (nskk-it "T-04: nskk--deferred-vowel-shadow-state is nil after rollback-conversion"
+    ;; Regression for FR-001.
+    ;; "Kash" sets DV in preedit; SPC triggers conversion; C-g rolls back.
+    ;; nskk-rollback-conversion calls nskk--clear-azik-pending-state, which
+    ;; must also clear DV so the next vowel does not retroactively rewrite the
+    ;; rolled-back reading.
+    (let ((dict '(("かすう" . ("加数")))))
+      (nskk-e2e-with-azik-buffer 'hiragana dict
+        (nskk-e2e-type "Kash")
+        (nskk-e2e-type "SPC")
+        (nskk-e2e-type "C-g")
+        (should (not (bound-and-true-p nskk--deferred-vowel-shadow-state)))
+        (nskk-e2e-type "a")
+        (nskk-e2e-assert-buffer "▽かすうあ")))))
 
 ;;;;
 ;;;; Section 19: Output correctness PBT — sokuon via DA correction (P-04)

--- a/test/unit/nskk-input-test.el
+++ b/test/unit/nskk-input-test.el
@@ -829,6 +829,24 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
              (should (string-match-p (regexp-quote (concat nskk-henkan-on-marker "か" nskk-okurigana-marker))
                                      (buffer-string))))))))))
 
+(nskk-describe "deferred vowel-shadow continuation policy"
+  (nskk-it "attaches uppercase-vowel continuation policy only for ch/sh/th"
+    (dolist (romaji '("ch" "sh" "th"))
+      (should (eq (nskk--deferred-vowel-shadow-policy-for-input romaji)
+                  nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy)))
+    (should-not (nskk--deferred-vowel-shadow-policy-for-input "wh"))
+    (should-not (nskk--deferred-vowel-shadow-policy-for-input "zh")))
+
+  (nskk-it "recognizes uppercase-vowel continuation only when the payload policy allows it"
+    (let ((nskk--deferred-vowel-shadow-state
+           (nskk--make-deferred-vowel-shadow
+            "sh" "すう"
+            (nskk--deferred-vowel-shadow-policy-for-input "sh"))))
+      (should (nskk--deferred-vowel-shadow-uppercase-continuation-p ?O)))
+    (let ((nskk--deferred-vowel-shadow-state
+           (nskk--make-deferred-vowel-shadow "wh" "うう" nil)))
+      (should-not (nskk--deferred-vowel-shadow-uppercase-continuation-p ?O)))))
+
 ;;;
 ;;; Inline Marker Constant Tests
 ;;;

--- a/test/unit/nskk-keymap-test.el
+++ b/test/unit/nskk-keymap-test.el
@@ -1176,7 +1176,8 @@ and configures state."
   (nskk-it "returns non-nil and clears DV (deferred-vowel-shadow-state)"
     (with-temp-buffer
       (let ((nskk--romaji-buffer "")
-            (nskk--deferred-vowel-shadow-state (cons "sh" "すう")))
+            (nskk--deferred-vowel-shadow-state
+             (nskk--make-deferred-vowel-shadow "sh" "すう")))
         (insert "すう")
         (goto-char (point-max))
         (should (nskk--backspace-retract-pending))
@@ -1286,14 +1287,17 @@ and configures state."
           (should-not nskk--deferred-azik-state)
           (should (equal (buffer-string) "▽"))))))
 
-  (nskk-it "BS rolls back DV (deferred-vowel-shadow-state)"
+  (nskk-it "BS rolls back DV payload with continuation policy"
     (nskk-with-mocks ((nskk--get-conversion-start (lambda () 1))
                       (nskk-cancel-preedit (lambda () nil)))
       (with-temp-buffer
         (let ((nskk-henkan-on-marker "▽")
               (nskk--romaji-buffer "")
-              (nskk--deferred-vowel-shadow-state (cons "sh" "すう")))
-          (insert "▽すう")
+              (nskk--deferred-vowel-shadow-state
+               (nskk--make-deferred-vowel-shadow
+                "ch" "ちゅう"
+                nskk--deferred-vowel-shadow-uppercase-vowel-continue-policy)))
+          (insert "▽ちゅう")
           (goto-char (point-max))
           (nskk--backspace-in-preedit)
           (should-not nskk--deferred-vowel-shadow-state)


### PR DESCRIPTION
## Summary

- Promotes `nskk--deferred-vowel-shadow-state` from a bare cons to a `cl-defstruct` with an optional `continuation-policy` field
- For the vowel-shadow keys `ch`, `sh`, and `th`, attaches the `uppercase-vowel-continue` policy so that a following vowel bypasses the standard DV retroactive correction when:
  - The vowel is **uppercase** (A/I/U/E/O) in any mode, OR
  - The vowel is **lowercase** (a/i/u/e/o) while **conversion mode (▽) is active**

## Behaviour

| Input | Context | Result |
|-------|---------|--------|
| `Cho` | hiragana, ▽ open | `▽ちゅうお` ✅ |
| `ChO` | hiragana, ▽ open | `▽ちゅうお` ✅ |
| `cho` | plain hiragana | `ちょ` (DV corrects, unchanged) |
| `Sha` | hiragana, ▽ open | `▽すうあ` ✅ |
| `sha` | plain hiragana | `しゃ` (DV corrects, unchanged) |

The conversion-mode branch fixes `Cho → ▽ちゅうお`: the user sees `ちゅう` tentatively after `Ch` and expects `o` to extend the reading, not replace it with `ちょ` via the DV correction.

## Test plan

- [x] `ChO`, `ShO`, `ThO` → ▽ちゅうお / ▽すうお / ▽つうお
- [x] All five vowels: `ChA`, `ShI`, `ThU`, `ChE`, `ChO`
- [x] `Cho`, `Sha` → continuation in conversion mode
- [x] `cho`, `sha` → DV correction preserved in plain hiragana mode
- [x] 5638/5638 tests pass