### PR TITLE
fix: preserve direct self-insert hooks

### DIFF
--- a/nskk-input.el
+++ b/nskk-input.el
@@ -588,9 +588,12 @@ Three-stage pipeline:
         (nskk--route-input char n mode)))))
 
 (defun/done nskk-insert-char (char &optional n)
-  "Insert CHAR into the buffer N times without any kana conversion."
-  (let ((n (or n 1)))
-    (insert (make-string n char))))
+  "Insert CHAR into the buffer N times without any kana conversion.
+Uses Emacs's normal self-insert machinery so direct ascii/latin input keeps
+standard observer semantics such as `post-self-insert-hook'."
+  (let ((n (or n 1))
+        (last-command-event char))
+    (self-insert-command n char)))
 
 (defun/done nskk-insert-fullwidth-char (char &optional n)
   "Insert full-width version of ASCII CHAR N times.

--- a/test/unit/nskk-input-test.el
+++ b/test/unit/nskk-input-test.el
@@ -346,7 +346,78 @@ incomplete consonant sequences (e.g. \"k\", \"x\") are classified as
       (with-temp-buffer
         (let ((last-command-event ?z))
           (nskk-when (nskk-self-insert 3))
-          (nskk-then (should (string= (buffer-string) "zzz"))))))))
+          (nskk-then (should (string= (buffer-string) "zzz")))))))
+
+  (nskk-it "preserves post-self-insert-hook and repeat count in ascii mode"
+    (with-temp-buffer
+      (nskk-mode 1)
+      (setf (nskk-state-mode nskk-current-state) 'ascii)
+      (let ((events nil)
+            (last-command-event ?a))
+        (add-hook 'post-self-insert-hook
+                  (lambda () (push last-command-event events))
+                  nil :local)
+        (nskk-when (nskk-self-insert 3))
+        (nskk-then
+         (should (string= (buffer-string) "aaa"))
+         (should (equal events '(?a)))))))
+
+  (nskk-it "preserves electric-pair semantics in ascii mode under nskk-mode"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (nskk-mode 1)
+      (setf (nskk-state-mode nskk-current-state) 'ascii)
+      (electric-pair-local-mode 1)
+      (let ((last-command-event ?\())
+        (nskk-when (nskk-self-insert 1))
+        (nskk-then
+         (should (string= (buffer-string) "()"))
+         (should (= (point) 2))))))
+
+  (nskk-it "preserves electric-pair semantics in latin mode under nskk-global-mode"
+    (unwind-protect
+        (with-temp-buffer
+          (emacs-lisp-mode)
+          (nskk-global-mode 1)
+          (should nskk-mode)
+          (setf (nskk-state-mode nskk-current-state) 'latin)
+          (electric-pair-local-mode 1)
+          (let ((last-command-event ?\())
+            (nskk-when (nskk-self-insert 1))
+            (nskk-then
+             (should (string= (buffer-string) "()"))
+             (should (= (point) 2)))))
+      (nskk-global-mode -1)))
+
+  (nskk-it "preserves candidate selection before direct insertion"
+    (with-temp-buffer
+      (nskk-mode 1)
+      (setf (nskk-state-mode nskk-current-state) 'ascii
+            (nskk-state-candidates nskk-current-state) '("漢字" "感じ"))
+      (let ((last-command-event ?a)
+            (committed nil)
+            (nskk--henkan-candidate-list-active t)
+            (nskk-henkan-select-candidate-by-key-function
+             (lambda (char _cands _idx)
+               (when (= char ?a) 0))))
+        (nskk-with-mocks ((nskk-commit-current (lambda () (setq committed t))))
+          (nskk-when (nskk-self-insert 1))
+          (nskk-then
+           (should committed)
+           (should (string= (buffer-string) "")))))))
+
+  (nskk-it "preserves implicit kakutei before direct insertion"
+    (with-temp-buffer
+      (nskk-mode 1)
+      (setf (nskk-state-mode nskk-current-state) 'ascii)
+      (let ((last-command-event ?a)
+            (committed nil))
+        (nskk-with-mocks ((nskk--implicit-kakutei-needed-p (lambda () t))
+                          (nskk-commit-current (lambda () (setq committed t))))
+          (nskk-when (nskk-self-insert 1))
+          (nskk-then
+           (should committed)
+           (should (string= (buffer-string) "a"))))))))
 
 ;;;
 ;;; Error Handling: Conversion State Guards


### PR DESCRIPTION
## Summary
- Route ascii/latin direct insertion through Emacs `self-insert-command` so `post-self-insert-hook` observers work again.
- Add regressions for `electric-pair-mode`, hook/repeat behavior, candidate selection, and implicit kakutei ordering.

## Verification
- Byte-compiled `nskk-input.el` and `test/unit/nskk-input-test.el` with `byte-compile-error-on-warn`.
- Ran targeted input ERT: `278/278` tests passed.
- Ran manual smoke: `NSKK-SMOKE-PASS (ascii-electric latin-electric hook)`.
- Ran 5-agent post-implementation review: goal, QA, code quality, security, and context mining all passed.

## Notes
- Scope is intentionally limited to `ascii` and `latin`; `jisx0208-latin`, `abbrev`, and Japanese modes keep their existing routes.