### PR TITLE
security: safe-local-variable remediation for external execution and path variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ vendor/
 # Nix build results
 result
 flake.lock
+
+# package-lint local cache
+.package-lint-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opposite order from DDSKK.  Unit tests updated to document the correct
   pass-through semantics.
 
+### Security
+
+- **safe-local-variable remediation**: Removed `:safe` predicates and added
+  `:risky t` markers to variables that control external process execution and
+  network connections.  These variables can no longer be set silently via
+  `.dir-locals.el`; Emacs will now warn or block when a project-local file
+  attempts to configure them.
+
+  **Variables marked `:risky t`** (Emacs blocks even if added to
+  `safe-local-variable-values`):
+  - `nskk-program-dict-enable`, `nskk-program-dicts` — control arbitrary
+    Emacs Lisp callbacks and external shell process execution
+  - `nskk-server-enable`, `nskk-server-host`, `nskk-server-portnum` — control
+    plaintext TCP connections to skkserv instances
+
+  **Variables with `:safe` removed** (Emacs prompts before applying):
+  - `nskk-server-coding-system`, `nskk-server-timeout`, `nskk-server-report-response`
+  - `nskk-dict-user-dictionary-file`, `nskk-dict-system-dictionary-files`,
+    `nskk-large-dictionary`, `nskk-search-learning-file`, `nskk-kakutei-jisyo`,
+    `nskk-study-file`
+
+  **Migration**: Move any of these variables from `.dir-locals.el` to your
+  `init.el` using `setq`, or accept the Emacs safety prompt on each directory
+  visit.
+
 ### Added
 
 - **AZIK y-prefix youon rows**: AZIK mode now supports standard romaji y-prefix

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,18 @@ lint-checkdoc:
 	$(BATCH) $(LOAD_PATH) \
 	  $(foreach f,$(SRC),--eval "(checkdoc-file \"$(f)\")")
 
+PACKAGE_LINT_CACHE := $(CURDIR)/.package-lint-cache
+
 package-lint:
 	$(BATCH) $(LOAD_PATH) \
-	  --eval "(progn (require 'package) (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) (package-initialize) (package-refresh-contents) (package-install 'package-lint))" \
+	  --eval "(progn \
+	    (require 'package) \
+	    (setq package-user-dir \"$(PACKAGE_LINT_CACHE)\") \
+	    (push '(\"melpa-stable\" . \"https://stable.melpa.org/packages/\") package-archives) \
+	    (package-initialize) \
+	    (unless (package-installed-p 'package-lint) \
+	      (package-refresh-contents) \
+	      (package-install 'package-lint)))" \
 	  -l package-lint \
 	  -f package-lint-batch-and-exit src/nskk.el
 

--- a/src/nskk-custom.el
+++ b/src/nskk-custom.el
@@ -154,7 +154,6 @@ Zero disables fuzzy matching."
   (expand-file-name "nskk/learning.dat" user-emacs-directory)
   "File path for persisting learning data."
   :type 'file
-  :safe #'stringp
   :package-version '(nskk . "0.1.0")
   :group 'nskk-search)
 
@@ -373,7 +372,6 @@ without showing a candidate selection menu.  When a reading matches an
 entry in this dictionary, the single candidate is inserted directly.
 The file format is the same as the standard SKK dictionary format."
   :type '(choice file (const nil))
-  :safe (lambda (v) (or (null v) (stringp v)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-kakutei-jisyo)
 

--- a/src/nskk-dictionary.el
+++ b/src/nskk-dictionary.el
@@ -87,7 +87,6 @@
   (expand-file-name "~/.nskk/jisyo")
   "Path to the user dictionary file for storing registered words."
   :type 'file
-  :safe #'stringp
   :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
@@ -96,7 +95,6 @@
 When nil, NSKK auto-detects dictionary paths from nix profiles
 and common system locations."
   :type '(repeat file)
-  :safe (lambda (v) (and (listp v) (cl-every #'stringp v)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
@@ -127,7 +125,6 @@ Possible values:
 (defcustom nskk-large-dictionary nil
   "Path to large SKK dictionary file, or nil to disable."
   :type '(choice file (const nil))
-  :safe (lambda (v) (or (null v) (stringp v)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-dictionary)
 
@@ -748,9 +745,14 @@ are empty/invalid or when the Prolog unregistration query fails."
         (let ((key        (car binding))
               (candidates (cadr binding)))
           (when (and key candidates)
-            (insert (format "%s /%s/\n"
-                            key
-                            (string-join candidates "/")))))))
+            (let ((safe-cands (seq-remove
+                               (lambda (c) (string-match-p "[\n\r/]" c))
+                               candidates)))
+              (when (and (not (string-match-p "[\n\r]" key))
+                         safe-cands)
+                (insert (format "%s /%s/\n"
+                                key
+                                (string-join safe-cands "/")))))))))
     (message "NSKK: User dictionary saved to %s"
              nskk-dict-user-dictionary-file)
     (setq nskk-dict-modified nil)))

--- a/src/nskk-program-dictionary.el
+++ b/src/nskk-program-dictionary.el
@@ -106,7 +106,7 @@ To enable program dictionary lookup:
     (list (lambda (r) (my-lookup r))
           \"/usr/local/bin/my-dict %s\"))"
   :type 'boolean
-  :safe #'booleanp
+  :risky t
   :group 'nskk-program-dict)
 
 (defcustom nskk-program-dicts nil
@@ -137,9 +137,7 @@ Example:
       \"/usr/local/bin/my-dict %s\"       ; %s replaced by reading (as arg)
       \"my-stdin-dict\"))                  ; reading sent via stdin"
   :type '(repeat (choice function string))
-  :safe (lambda (v)
-          (and (listp v)
-               (cl-every (lambda (e) (or (functionp e) (stringp e))) v)))
+  :risky t
   :group 'nskk-program-dict)
 
 (defcustom nskk-program-dict-timeout 1.0

--- a/src/nskk-server.el
+++ b/src/nskk-server.el
@@ -109,7 +109,7 @@ To enable skkserv lookup:
   (setq nskk-server-host \"localhost\")
   (setq nskk-server-portnum 1178)"
   :type 'boolean
-  :safe #'booleanp
+  :risky t
   :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
@@ -118,7 +118,7 @@ To enable skkserv lookup:
 Only used when `nskk-server-enable' is non-nil.
 Note: connections to non-localhost hosts are unencrypted plaintext TCP."
   :type 'string
-  :safe #'stringp
+  :risky t
   :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
@@ -126,7 +126,7 @@ Note: connections to non-localhost hosts are unencrypted plaintext TCP."
   "TCP port number of the skkserv instance.
 The default port 1178 is registered as \\='skkserv\\=' in /etc/services."
   :type 'natnum
-  :safe #'natnump
+  :risky t
   :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
@@ -135,7 +135,6 @@ The default port 1178 is registered as \\='skkserv\\=' in /etc/services."
 Traditional skkserv implementations use EUC-JP.  Modern servers such as
 yaskkserv2 may use UTF-8; set this to \\='utf-8 in that case."
   :type 'coding-system
-  :safe #'coding-system-p
   :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
@@ -147,7 +146,6 @@ smaller values improve responsiveness when the server is unreachable.
 Note: enabling skkserv may exceed the package's < 10ms search latency
 target when the server is remote or slow."
   :type 'number
-  :safe #'numberp
   :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 
@@ -156,7 +154,6 @@ target when the server is remote or slow."
 Useful for diagnosing latency issues.  Requires `nskk-debug-enabled' to
 be non-nil for the log entries to appear."
   :type 'boolean
-  :safe #'booleanp
   :package-version '(nskk . "0.1.0")
   :group 'nskk-server)
 

--- a/src/nskk-study.el
+++ b/src/nskk-study.el
@@ -66,7 +66,6 @@
   (expand-file-name "nskk/study.dat" user-emacs-directory)
   "File path for persisting study association data."
   :type 'file
-  :safe #'stringp
   :package-version '(nskk . "0.1.0")
   :group 'nskk-study)
 
@@ -226,19 +225,25 @@ of the list.  Returns the (possibly reordered) candidate list."
   "Load study association data from `nskk-study-file'."
   (interactive)
   (when (file-readable-p nskk-study-file)
-    (condition-case err
-        (when-let* ((data (with-temp-buffer
-                            (insert-file-contents nskk-study-file)
-                            (read (current-buffer)))))
-          (dolist (entry data)
-            (pcase entry
-              (`(,(and (pred stringp) prev)
-                 ,(and (pred stringp) reading)
-                 ,(and (pred stringp) cand))
-               (nskk-prolog-assert
-                (list `(study-association ,prev ,reading ,cand)))))))
-      (error
-       (message "NSKK: Failed to load study data: %s" (error-message-string err))))))
+    (let ((size (file-attribute-size
+                 (file-attributes nskk-study-file))))
+      (if (and size (> size (* 10 1024 1024)))
+          (message "NSKK: Study file too large (%d bytes), skipping load" size)
+        (condition-case err
+            (when-let* ((data (with-temp-buffer
+                                (insert-file-contents nskk-study-file)
+                                (read (current-buffer)))))
+              (unless (listp data)
+                (error "Expected list, got %s" (type-of data)))
+              (dolist (entry data)
+                (pcase entry
+                  (`(,(and (pred stringp) prev)
+                     ,(and (pred stringp) reading)
+                     ,(and (pred stringp) cand))
+                   (nskk-prolog-assert
+                    (list `(study-association ,prev ,reading ,cand)))))))
+          (error
+           (message "NSKK: Failed to load study data: %s" (error-message-string err))))))))
 
 (provide 'nskk-study)
 

--- a/test/unit/nskk-custom-test.el
+++ b/test/unit/nskk-custom-test.el
@@ -199,14 +199,11 @@
          (nskk-show-tooltip                        nil)
          (nskk-dcomp-multiple-activate             t)
          (nskk-dcomp-multiple-activate             nil)
-         (nskk-kakutei-jisyo                       nil)
-         (nskk-kakutei-jisyo                       "/tmp/test-kakutei.dat")
          (nskk-state-default-mode                  ascii)
          (nskk-state-default-mode                  hiragana)
          (nskk-converter-romaji-style              azik)
          (nskk-search-sort-method                  kana)
          (nskk-modeline-format                     " SKK")
-         (nskk-search-learning-file                "/tmp/test.dat")
          (nskk-henkan-show-candidates-keys         (?a ?s ?d))
          (nskk-henkan-show-candidates-keys         nil))
   :description ":safe predicate accepts valid-typed values"
@@ -223,8 +220,6 @@
          (nskk-state-default-mode             42)
          (nskk-state-default-mode             "ascii")
          (nskk-modeline-format                42)
-         (nskk-search-learning-file           42)
-         (nskk-kakutei-jisyo                  42)
          (nskk-henkan-show-candidates-keys    ("a" "b")))
   :description ":safe predicate rejects wrong-typed values"
   :body (should-not (funcall (get var 'safe-local-variable) invalid-value)))
@@ -256,8 +251,7 @@
 (nskk-property-test-seeded custom-pbt-string-vars-accept-strings
   ((s romaji-string))
   (and (stringp s)
-       (funcall (get 'nskk-modeline-format 'safe-local-variable) s)
-       (funcall (get 'nskk-search-learning-file 'safe-local-variable) s))
+       (funcall (get 'nskk-modeline-format 'safe-local-variable) s))
   30 42)
 
 ;; PBT-003 — Boolean custom vars accept only t or nil (exhaustive via seeded)
@@ -292,6 +286,20 @@
      (not (funcall keys-pred '("a" "s" "d")))
      (not (funcall keys-pred "asd"))))
   20 42)
+
+;;;
+;;; safe-local-variable policy — path and file variables
+;;;
+
+(nskk-describe "path variable safe-local-variable policy"
+  (nskk-it "no path variable has a safe-local-variable predicate"
+    (dolist (sym '(nskk-search-learning-file
+                   nskk-kakutei-jisyo
+                   nskk-dict-user-dictionary-file
+                   nskk-dict-system-dictionary-files
+                   nskk-large-dictionary
+                   nskk-study-file))
+      (should-not (get sym 'safe-local-variable)))))
 
 (provide 'nskk-custom-test)
 

--- a/test/unit/nskk-dictionary-test.el
+++ b/test/unit/nskk-dictionary-test.el
@@ -1498,6 +1498,42 @@ The file is written in SKK-JISYO format, loaded, and cleaned up after BODY."
                                   (lambda () (setq not-found t)))
         (should not-found)))))
 
+;;;
+;;; Dict save sanitization tests
+;;;
+
+(nskk-describe "nskk-dict-save-user-dictionary sanitization"
+  (nskk-it "skips keys containing newline when saving"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-prolog-assert '((user-dict-entry "bad\nkey" ("候補"))))
+      (nskk-prolog-assert '((user-dict-entry "よみ" ("候補"))))
+      (let ((nskk-dict-user-dictionary-file (make-temp-file "nskk-test-dict"))
+            (nskk--user-dict-index t))
+        (unwind-protect
+            (progn
+              (nskk-dict-save-user-dictionary)
+              (let ((content (with-temp-buffer
+                               (insert-file-contents nskk-dict-user-dictionary-file)
+                               (buffer-string))))
+                (should (string-match-p "よみ" content))
+                (should-not (string-match-p "bad" content))))
+          (delete-file nskk-dict-user-dictionary-file)))))
+
+  (nskk-it "skips candidates containing / when saving"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-prolog-assert '((user-dict-entry "よみ" ("正常" "不/正" "正常2"))))
+      (let ((nskk-dict-user-dictionary-file (make-temp-file "nskk-test-dict"))
+            (nskk--user-dict-index t))
+        (unwind-protect
+            (progn
+              (nskk-dict-save-user-dictionary)
+              (let ((content (with-temp-buffer
+                               (insert-file-contents nskk-dict-user-dictionary-file)
+                               (buffer-string))))
+                (should (string-match-p "正常" content))
+                (should-not (string-match-p "不/正" content))))
+          (delete-file nskk-dict-user-dictionary-file))))))
+
 (provide 'nskk-dictionary-test)
 
 ;;; nskk-dictionary-test.el ends here

--- a/test/unit/nskk-program-dictionary-test.el
+++ b/test/unit/nskk-program-dictionary-test.el
@@ -1245,6 +1245,41 @@ Resets `nskk--program-dict-cache' to nil so each test starts cache-free."
                     result))))
   20)
 
+;;;
+;;; safe-local-variable policy
+;;;
+
+(nskk-describe "nskk-program-dict-enable safe-local-variable policy"
+  (nskk-it "is marked as risky-local-variable"
+    (should (get 'nskk-program-dict-enable 'risky-local-variable)))
+
+  (nskk-it "is classified as risky by risky-local-variable-p"
+    (should (risky-local-variable-p 'nskk-program-dict-enable)))
+
+  (nskk-it "has no safe-local-variable predicate"
+    (should-not (get 'nskk-program-dict-enable 'safe-local-variable))))
+
+(nskk-describe "nskk-program-dicts safe-local-variable policy"
+  (nskk-it "is marked as risky-local-variable"
+    (should (get 'nskk-program-dicts 'risky-local-variable)))
+
+  (nskk-it "is classified as risky by risky-local-variable-p"
+    (should (risky-local-variable-p 'nskk-program-dicts)))
+
+  (nskk-it "has no safe-local-variable predicate"
+    (should-not (get 'nskk-program-dicts 'safe-local-variable))))
+
+(nskk-describe "nskk-program-dicts malicious dir-locals scenario"
+  (nskk-it "lambda injection is rejected by safe-local-variable-p"
+    (should-not (safe-local-variable-p 'nskk-program-dicts
+                                       (list (lambda (k) (shell-command k))))))
+
+  (nskk-it "shell command string is rejected by safe-local-variable-p"
+    (should-not (safe-local-variable-p 'nskk-program-dicts '("rm -rf ~ %s"))))
+
+  (nskk-it "enable flag injection is rejected by safe-local-variable-p"
+    (should-not (safe-local-variable-p 'nskk-program-dict-enable t))))
+
 (provide 'nskk-program-dictionary-test)
 
 ;;; nskk-program-dictionary-test.el ends here

--- a/test/unit/nskk-server-test.el
+++ b/test/unit/nskk-server-test.el
@@ -723,6 +723,27 @@ Restores server-state to closed in an unwind-protect."
               (setq result (nskk--server-with-response "key"))))))
       (should (null result)))))
 
+;;;
+;;; safe-local-variable policy
+;;;
+
+(nskk-describe "nskk-server-* risky-local-variable policy"
+  (nskk-it "nskk-server-enable is marked risky-local-variable"
+    (should (get 'nskk-server-enable 'risky-local-variable)))
+
+  (nskk-it "nskk-server-host is marked risky-local-variable"
+    (should (get 'nskk-server-host 'risky-local-variable)))
+
+  (nskk-it "nskk-server-portnum is marked risky-local-variable"
+    (should (get 'nskk-server-portnum 'risky-local-variable))))
+
+(nskk-describe "nskk-server-* safe-local-variable policy"
+  (nskk-it "no nskk-server-* variable has a safe-local-variable predicate"
+    (dolist (sym '(nskk-server-enable nskk-server-host nskk-server-portnum
+                   nskk-server-coding-system nskk-server-timeout
+                   nskk-server-report-response))
+      (should-not (get sym 'safe-local-variable)))))
+
 (provide 'nskk-server-test)
 
 ;;; nskk-server-test.el ends here

--- a/test/unit/nskk-study-test.el
+++ b/test/unit/nskk-study-test.el
@@ -288,6 +288,36 @@
                              "予報")))
           (delete-file nskk-study-file))))))
 
+;;;
+;;; nskk-study-load validation tests
+;;;
+
+(nskk-describe "nskk-study-load validation"
+  (nskk-it "rejects non-list data and does not crash"
+    (let ((tmpfile (make-temp-file "nskk-test-study")))
+      (unwind-protect
+          (progn
+            (with-temp-file tmpfile
+              (prin1 "not-a-list" (current-buffer)))
+            (let ((nskk-study-file tmpfile))
+              (nskk-prolog-test-with-isolated-db
+                (nskk-study-load)
+                (should-not (nskk-prolog-holds-p '(study-association \?_ \?_ \?_))))))
+        (delete-file tmpfile))))
+
+  (nskk-it "loads valid list data without error"
+    (let ((tmpfile (make-temp-file "nskk-test-study")))
+      (unwind-protect
+          (progn
+            (with-temp-file tmpfile
+              (prin1 '(("prev" "reading" "cand")) (current-buffer)))
+            (let ((nskk-study-file tmpfile))
+              (nskk-prolog-test-with-isolated-db
+                (nskk-study-load)
+                (should (nskk-prolog-holds-p
+                         '(study-association "prev" "reading" "cand"))))))
+        (delete-file tmpfile)))))
+
 (provide 'nskk-study-test)
 
 ;;; nskk-study-test.el ends here


### PR DESCRIPTION
## Summary

- **`:risky t`** added to `nskk-program-dict-enable`, `nskk-program-dicts`, `nskk-server-enable`, `nskk-server-host`, `nskk-server-portnum` — Emacs blocks these even if added to `safe-local-variable-values`, preventing arbitrary external process execution and plaintext TCP connection activation via `.dir-locals.el`
- **`:safe` removed** from all file/path variables (`nskk-dict-user-dictionary-file`, `nskk-dict-system-dictionary-files`, `nskk-large-dictionary`, `nskk-search-learning-file`, `nskk-study-file`, `nskk-kakutei-jisyo`, `nskk-server-coding-system`, `nskk-server-timeout`, `nskk-server-report-response`) — Emacs now prompts before applying
- **Dict-save sanitization**: `nskk-dict-save-user-dictionary` now strips candidates containing `/` or newlines to prevent format corruption
- **Study-load hardening**: `nskk-study-load` now checks file size (10 MB limit) and validates top-level type before asserting Prolog facts
- **CI improvement**: `package-lint` Makefile target now uses a local cache dir (`.package-lint-cache/`) and `melpa-stable` to avoid re-downloading on every run

## Migration

Move any of these variables from `.dir-locals.el` to your `init.el` using `setq`, or accept the Emacs safety prompt on each directory visit.

## Test plan

- [ ] `make compile` — zero byte-compile warnings
- [ ] `make test-unit` — all unit tests pass including new policy/sanitization tests
- [ ] `risky-local-variable-p` returns `t` for `nskk-program-dict-enable`, `nskk-program-dicts`, `nskk-server-enable`, `nskk-server-host`, `nskk-server-portnum`
- [ ] `safe-local-variable-p` returns `nil` for all path variables
- [ ] Malicious `.dir-locals.el` scenario tests in `nskk-program-dictionary-test.el`