### PR TITLE
fix: correct nskk-mode modeline lighter

### DIFF
--- a/src/nskk.el
+++ b/src/nskk.el
@@ -180,7 +180,7 @@ to control per-mode cursor color changes.
 
 \\{nskk-mode-map}"
   :init-value nil
-  :lighter '(:eval (nskk-modeline-indicator))
+  :lighter (:eval (nskk-modeline-indicator))
   :keymap nskk-mode-map
   :group 'nskk
   (if nskk-mode

--- a/test/unit/nskk-test.el
+++ b/test/unit/nskk-test.el
@@ -32,6 +32,12 @@
   (nskk-it "is an interactive command"
     (should (commandp 'nskk-mode)))
 
+  (nskk-it "registers the dynamic modeline lighter without an extra quote"
+    (let ((entry (assq (quote nskk-mode) minor-mode-alist))
+          (expected (quote (:eval (nskk-modeline-indicator)))))
+      (should entry)
+      (should (equal (cadr entry) expected))))
+
   (nskk-it "enables nskk-mode in a buffer"
     (with-temp-buffer
       (nskk-mode 1)


### PR DESCRIPTION
## Summary
- Fix the `nskk-mode` `:lighter` form so Emacs registers `(:eval (nskk-modeline-indicator))` without an extra quote.
- Add a regression test that checks the `minor-mode-alist` entry directly, covering the wiring bug that direct modeline function tests would miss.

## Verification
- Confirmed `define-minor-mode` macro expansion for quoted vs unquoted `:lighter` forms.
- Confirmed `(assq 'nskk-mode minor-mode-alist)` returns `(nskk-mode (:eval (nskk-modeline-indicator)))`.
- `test/unit/nskk-test.el`: 54/54 passed.
- `make test`: 5657/5657 passed.
- `make lint`: completed with existing checkdoc warnings.
- `make package-lint`: passed.
- Oracle review: PASS.

Closes #47