### PR TITLE
feat(search): persist learning data across sessions

### DIFF
--- a/src/nskk-custom.el
+++ b/src/nskk-custom.el
@@ -157,6 +157,19 @@ Zero disables fuzzy matching."
   :package-version '(nskk . "0.1.0")
   :group 'nskk-search)
 
+(defcustom nskk-search-auto-save-learning t
+  "When non-nil, persist learning data across Emacs sessions.
+When enabled, learning scores are loaded from `nskk-search-learning-file'
+the first time NSKK is enabled, and saved back on Emacs exit via
+`kill-emacs-hook'.  If the optional study feature (`nskk-study') is
+loaded, study association data is loaded and saved as well.
+
+When nil, learning is kept in memory only and lost when Emacs exits."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(nskk . "0.1.0")
+  :group 'nskk-search)
+
 ;;;; UI / Modeline Settings
 
 (defgroup nskk-modeline nil

--- a/src/nskk-search.el
+++ b/src/nskk-search.el
@@ -467,6 +467,35 @@ the integer Levenshtein distance from QUERY."
     (error
      (message "NSKK: Failed to save learning data: %s" (error-message-string err)))))
 
+;;;###autoload
+(defun nskk-search-load-learning-data ()
+  "Load learning data from `nskk-search-learning-file'.
+Restore the `learning-score' Prolog facts serialized by
+`nskk-search-save-learning-data'.  This is the inverse operation,
+allowing learning to persist across Emacs sessions."
+  (interactive)
+  (when (file-readable-p nskk-search-learning-file)
+    (let ((size (file-attribute-size
+                 (file-attributes nskk-search-learning-file))))
+      (if (and size (> size (* 10 1024 1024)))
+          (message "NSKK: Learning file too large (%d bytes), skipping load" size)
+        (condition-case err
+            (when-let* ((data (with-temp-buffer
+                                (insert-file-contents nskk-search-learning-file)
+                                (read (current-buffer)))))
+              (unless (listp data)
+                (error "Expected list, got %s" (type-of data)))
+              (dolist (entry data)
+                (pcase entry
+                  (`(,(and (pred stringp) reading)
+                     ,(and (pred stringp) word)
+                     ,(and (pred integerp) score))
+                   (nskk-prolog-assert
+                    (list `(learning-score ,reading ,word ,score)))))))
+          (error
+           (message "NSKK: Failed to load learning data: %s"
+                    (error-message-string err))))))))
+
 (defun/done nskk-search-learn (query candidate &optional context)
   "Record that CANDIDATE was selected for QUERY.
 _CONTEXT is reserved for future use.

--- a/src/nskk.el
+++ b/src/nskk.el
@@ -110,6 +110,10 @@
 (declare-function nskk--current-kakutei-state "nskk-keymap")
 (declare-function nskk--maybe-load-azik-style "nskk-input")
 (declare-function nskk--dict-maybe-save "nskk-dictionary")
+(declare-function nskk-search-load-learning-data "nskk-search")
+(declare-function nskk-search-save-learning-data "nskk-search")
+(declare-function nskk-study-load "nskk-study")
+(declare-function nskk-study-save "nskk-study")
 (declare-function nskk-handle-ctrl-a "nskk-keymap")
 (declare-function nskk-handle-ctrl-e "nskk-keymap")
 (declare-function nskk-handle-tab "nskk-keymap")
@@ -202,6 +206,19 @@ This provides global bindings that work even when nskk-mode is not yet active."
 
 ;; Internal implementation functions
 
+(defvar nskk--learning-loaded nil
+  "Non-nil once learning data has been loaded in this Emacs session.
+Guards `nskk--enable' so that learning data is loaded only once, not on
+every buffer activation.")
+
+(defun nskk--save-learning-data ()
+  "Save learning data (and study data when loaded) on Emacs exit.
+Registered on `kill-emacs-hook' by `nskk--enable' when
+`nskk-search-auto-save-learning' is non-nil."
+  (nskk-search-save-learning-data)
+  (when (featurep 'nskk-study)
+    (nskk-study-save)))
+
 (defun nskk--enable ()
   "Enable NSKK in current buffer."
   (nskk-debug-message "NSKK is enabled in buffer: %s" (buffer-name))
@@ -235,6 +252,15 @@ This provides global bindings that work even when nskk-mode is not yet active."
   (nskk--maybe-load-azik-style)
   ;; Register save-on-exit hook; add-hook deduplicates same symbol safely
   (add-hook 'kill-emacs-hook #'nskk--dict-maybe-save)
+  ;; Persist learning data: load once on first enable, save on Emacs exit.
+  (when nskk-search-auto-save-learning
+    (unless nskk--learning-loaded
+      (setq nskk--learning-loaded t)
+      (nskk-search-load-learning-data)
+      ;; Study (contextual learning) is optional; persist it only when loaded.
+      (when (featurep 'nskk-study)
+        (nskk-study-load)))
+    (add-hook 'kill-emacs-hook #'nskk--save-learning-data))
   (nskk--setup-buffer)
   (nskk--cursor-color-save)
   (nskk-modeline-update))

--- a/test/unit/nskk-search-test.el
+++ b/test/unit/nskk-search-test.el
@@ -1413,6 +1413,42 @@ of keys under `string<' regardless of the input order."
   40
   43)
 
+;;; Learning data persistence (save / load round-trip)
+
+(nskk-describe "nskk-search-load-learning-data"
+  (nskk-it "round-trips learning scores through save and load"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk-search-learning-file (make-temp-file "nskk-learning" nil ".dat")))
+        (unwind-protect
+            (progn
+              (nskk-prolog-retract-all 'learning-score 3)
+              ;; Two candidates for the reading "ゆき"; "優響" has the higher score.
+              (nskk-prolog-assert (list '(learning-score "ゆき" "優響" 3)))
+              (nskk-prolog-assert (list '(learning-score "ゆき" "雪" 1)))
+              (nskk-search-save-learning-data)
+              ;; Wipe in-memory scores, then reload from the file.
+              (nskk-prolog-retract-all 'learning-score 3)
+              (should (null (nskk-prolog-query-value
+                             '(learning-score "ゆき" "優響" \?s) '\?s)))
+              (nskk-search-load-learning-data)
+              (should (= 3 (nskk-prolog-query-value
+                            '(learning-score "ゆき" "優響" \?s) '\?s)))
+              (should (= 1 (nskk-prolog-query-value
+                            '(learning-score "ゆき" "雪" \?s) '\?s))))
+          (delete-file nskk-search-learning-file)))))
+
+  (nskk-it "is a no-op when the learning file does not exist"
+    (nskk-prolog-test-with-isolated-db
+      (let ((nskk-search-learning-file
+             (expand-file-name "nskk-nonexistent-learning.dat"
+                               temporary-file-directory)))
+        (when (file-exists-p nskk-search-learning-file)
+          (delete-file nskk-search-learning-file))
+        (nskk-prolog-retract-all 'learning-score 3)
+        (nskk-search-load-learning-data)
+        (should (null (nskk-prolog-query-value
+                       '(learning-score "ゆき" "優響" \?s) '\?s)))))))
+
 (provide 'nskk-search-test)
 
 ;;; nskk-search-test.el ends here


### PR DESCRIPTION
## Summary

NSKK learns from each confirmation — `learning-score` for frequency, and
`study-association` for context when `nskk-study` is used — but this learning
is **never persisted across Emacs sessions**. It is lost on every restart.

## Problem

While investigating why learned candidate order was not retained, I found:

- `nskk-search-save-learning-data` exists, but there is **no counterpart
  loader** for learning scores.
- `nskk-study-load` is defined but **never called** from anywhere.
- No save hook is registered for learning/study data; only the user dictionary
  is saved on `kill-emacs-hook`.

So learning scores accumulate in memory and are discarded when Emacs exits.

### Example

1. Convert `ゆき` and select `優響`, then confirm. The `learning-score` for
   (ゆき, 優響) increases, so `優響` ranks higher within the same session.
2. Restart Emacs. The score is gone, and `優響` falls back to its original rank.

## How ddskk handles this

In ddskk the personal dictionary (`skk-jisyo`) doubles as the learning store:
every confirmation updates it via `skk-update-jisyo` (moving the chosen word to
the front of its entry), and it is persisted by `skk-save-jisyo` — on Emacs
exit and periodically (`skk-jisyo-save-count`) — then reloaded on startup. So
in ddskk learning survives restarts by construction.

NSKK instead keeps learning in separate stores (`learning-score`,
`study-association`) from the user dictionary. That separation is a reasonable
design, but the persistence half (a loader plus a save hook) was simply
missing. This PR fills that gap while keeping NSKK's store separation.

## Changes

- Add `nskk-search-load-learning-data`, the inverse of
  `nskk-search-save-learning-data`, restoring `learning-score` facts from
  `nskk-search-learning-file`.
- Load learning once on the first `nskk--enable`, and save it on
  `kill-emacs-hook`. Study data is loaded/saved as well when the optional
  `nskk-study` feature is loaded.
- Add `nskk-search-auto-save-learning` (default `t`) to toggle the behavior;
  set it to `nil` to keep learning in memory only.

## Testing

- New save → wipe → load round-trip tests in `test/unit/nskk-search-test.el`.
- `make compile` clean (warnings-as-errors), `make test` → **5663 / 5663
  passed**, `make lint` (checkdoc) clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)