### PR TITLE
feat(henkan): optionally merge user dictionary with skkserv results

### DIFF
--- a/src/nskk-custom.el
+++ b/src/nskk-custom.el
@@ -157,6 +157,25 @@ Zero disables fuzzy matching."
   :package-version '(nskk . "0.1.0")
   :group 'nskk-search)
 
+(defcustom nskk-search-merge-user-dict-with-server nil
+  "When non-nil, merge user dictionary candidates with skkserv results.
+
+By default (nil), skkserv takes priority: when a server lookup succeeds
+its candidates are used as-is and the local user dictionary is not
+consulted, matching the historical NSKK search behavior.
+
+When non-nil, the local dictionary (user-registered and learned words)
+is searched first and its candidates are merged ahead of the server's,
+with duplicates removed.  This is closer to ddskk, where the personal
+dictionary is merged before the system/server dictionaries so that
+registered and learned words always appear among the top candidates.
+
+Only affects exact dictionary lookup (`nskk-core-search')."
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(nskk . "0.1.0")
+  :group 'nskk-search)
+
 ;;;; UI / Modeline Settings
 
 (defgroup nskk-modeline nil

--- a/src/nskk-henkan.el
+++ b/src/nskk-henkan.el
@@ -366,6 +366,34 @@ Calls on-not-found for any non-confirmed result."
         :fail  (fail))
     (fail)))
 
+(defun nskk--merge-candidates-user-first (primary secondary)
+  "Merge candidate lists PRIMARY and SECONDARY, keeping PRIMARY first.
+Duplicates (compared with `equal') are removed, preferring PRIMARY's
+ordering.  Used to place user dictionary candidates ahead of server
+candidates when `nskk-search-merge-user-dict-with-server' is non-nil."
+  (delete-dups (append (copy-sequence primary) (copy-sequence secondary))))
+
+(defun/k nskk--core-dict-and-server (key)
+  "Look up KEY in the local dictionary and skkserv, then combine results.
+When `nskk-search-merge-user-dict-with-server' is non-nil, the local
+dictionary (which includes user-registered and learned words) is searched
+first and its candidates are merged ahead of the server's, with duplicates
+removed.  Otherwise the historical behavior is preserved: the server is
+tried first and the local dictionary is consulted only on a server miss."
+  (if nskk-search-merge-user-dict-with-server
+      (<-or local nskk-dict-lookup key
+        :found (<-or srv nskk--optional-server-lookup key
+                 :found (succeed (nskk--merge-candidates-user-first local srv))
+                 :fail  (succeed local))
+        :fail  (<-or srv nskk--optional-server-lookup key
+                 :found (succeed srv)
+                 :fail  (fail)))
+    (<-or srv nskk--optional-server-lookup key
+      :found (succeed srv)
+      :fail  (<-or local nskk-dict-lookup key
+               :found (succeed local)
+               :fail  (fail)))))
+
 ;; Search strategy: exact match → prefix fallback → partial match → skkserv (remote).
 ;; Each stage calls on-not-found to fall through to the next.
 ;; The type argument selects which stage is executed for a given call:
@@ -396,27 +424,27 @@ always pass both continuation arguments explicitly."
         (nskk-debug-log "[HENKAN] search: key=%s type=%s" key (or type 'exact))
         (pcase action
           ('dict-lookup
-           ;; Flat fallback chain:
-           ;;   kakutei-dict (confirmed, optional) → skkserv → local dict
+           ;; Fallback chain:
+           ;;   kakutei-dict (confirmed, optional) → dict-and-server
            ;;   → builtin-handlers → program-dict.
            ;; Kakutei dictionary is checked first: if it returns a single
            ;; confirmed candidate, it is committed immediately without
            ;; showing the candidate selection menu.
-           ;; skkserv is tried before local dict so that the server's
-           ;; richer dictionary and DDSKK-compatible ordering take priority.
+           ;; `nskk--core-dict-and-server' combines the local dictionary and
+           ;; skkserv.  By default the server takes priority (historical
+           ;; behavior); when `nskk-search-merge-user-dict-with-server' is
+           ;; non-nil it merges the user dictionary ahead of the server.
            ;; Enable-flag guards live inside each backend's own /k function.
            ;; fboundp guards in the optional-* wrappers handle unloaded modules.
            (<-or result nskk--optional-kakutei-lookup key
              :found (succeed result)
-             :fail  (<-or r nskk--optional-server-lookup key
-               :found (succeed r)
-               :fail  (<-or result2 nskk-dict-lookup key
-                 :found (succeed result2)
-                 :fail  (<-or b nskk--optional-program-dict-builtin-lookup key
-                   :found (succeed b)
-                   :fail  (<-or p nskk--optional-program-dict-lookup key
-                     :found (succeed p)
-                     :fail  (fail)))))))
+             :fail  (<-or ds nskk--core-dict-and-server key
+               :found (succeed ds)
+               :fail  (<-or b nskk--optional-program-dict-builtin-lookup key
+                 :found (succeed b)
+                 :fail  (<-or p nskk--optional-program-dict-lookup key
+                   :found (succeed p)
+                   :fail  (fail))))))
           ('prefix-search
            (if (nskk-dict-system-index)
                (<-or r nskk-search-prefix (nskk-dict-system-index) key nil limit

--- a/test/integration/nskk-server-henkan-integration-test.el
+++ b/test/integration/nskk-server-henkan-integration-test.el
@@ -144,6 +144,75 @@
           (nskk-server-close)
           (delete-process server-proc))))))
 
+;;;; User dictionary merged with server (opt-in via
+;;;; `nskk-search-merge-user-dict-with-server')
+
+(nskk-describe "user dictionary merged with server"
+
+  (nskk-it "merges user dict candidates ahead of server when enabled"
+    ;; Local dict has the registered word "優響"; the mock server returns
+    ;; other readings of "ゆき".  With merging enabled the user dict candidate
+    ;; comes first, followed by the server's.
+    (nskk-with-mock-dict '(("ゆき" . ("優響")))
+      (let* ((mock (nskk--server-start-mock-server
+                    '(("ゆき" . "1/雪/行き/\n"))))
+             (server-proc (car mock))
+             (port         (cdr mock))
+             (nskk-server-enable t)
+             (nskk-server-host "127.0.0.1")
+             (nskk-server-portnum port)
+             (nskk--server-process nil)
+             (nskk--server-kill-emacs-hook-registered nil)
+             (nskk-search-merge-user-dict-with-server t))
+        (unwind-protect
+            (progn
+              (should (nskk-server-open))
+              (let ((result (nskk-core-search "ゆき")))
+                (should (equal result '("優響" "雪" "行き")))))
+          (nskk-server-close)
+          (delete-process server-proc)))))
+
+  (nskk-it "deduplicates candidates shared by user dict and server"
+    ;; "雪" is present in both; it is kept once, with the user dict ordering.
+    (nskk-with-mock-dict '(("ゆき" . ("優響" "雪")))
+      (let* ((mock (nskk--server-start-mock-server
+                    '(("ゆき" . "1/雪/行き/\n"))))
+             (server-proc (car mock))
+             (port         (cdr mock))
+             (nskk-server-enable t)
+             (nskk-server-host "127.0.0.1")
+             (nskk-server-portnum port)
+             (nskk--server-process nil)
+             (nskk--server-kill-emacs-hook-registered nil)
+             (nskk-search-merge-user-dict-with-server t))
+        (unwind-protect
+            (progn
+              (should (nskk-server-open))
+              (let ((result (nskk-core-search "ゆき")))
+                (should (equal result '("優響" "雪" "行き")))))
+          (nskk-server-close)
+          (delete-process server-proc)))))
+
+  (nskk-it "falls back to server when merge enabled but user dict misses"
+    (nskk-with-mock-dict nskk-server-henkan--dict-without-test-key
+      (let* ((mock (nskk--server-start-mock-server
+                    '(("ゆき" . "1/雪/\n"))))
+             (server-proc (car mock))
+             (port         (cdr mock))
+             (nskk-server-enable t)
+             (nskk-server-host "127.0.0.1")
+             (nskk-server-portnum port)
+             (nskk--server-process nil)
+             (nskk--server-kill-emacs-hook-registered nil)
+             (nskk-search-merge-user-dict-with-server t))
+        (unwind-protect
+            (progn
+              (should (nskk-server-open))
+              (let ((result (nskk-core-search "ゆき")))
+                (should (member "雪" result))))
+          (nskk-server-close)
+          (delete-process server-proc))))))
+
 (provide 'nskk-server-henkan-integration-test)
 
 ;;; nskk-server-henkan-integration-test.el ends here


### PR DESCRIPTION
## Summary

When `nskk-server-enable` is on, a user-registered or learned word never
appears among the candidates for a reading that skkserv also knows. This adds
an opt-in option to merge the user dictionary ahead of the server, matching
ddskk's behavior.

## Problem

`nskk-core-search` (exact lookup) uses a flat fallback chain:

```
kakutei-dict → skkserv → local dict → builtin → program-dict
```

It is an **exclusive** fallback — it stops at the first source that returns
candidates. Since skkserv is consulted before the local dictionary, when the
server returns anything for a reading, the local user dictionary
(user-registered and learned words) is never merged in.

### Example

1. Register `ゆき → 優響` (`M-x` registration, "NSKK: Registered ゆき -> 優響").
2. Convert `ゆき` again. skkserv returns common candidates (`雪`, `行き`, …) and
   the chain stops there, so `優響` never shows up — the registration looks lost.

## How ddskk handles this

ddskk does **not** stop at the first dictionary. Its `skk-search-prog-list`
places the personal dictionary before the server:

```elisp
;; (excerpt of the default skk-search-prog-list)
(skk-search-jisyo-file skk-jisyo 0 t)          ; personal dictionary
...
(skk-search-jisyo-file skk-large-jisyo 10000)  ; system dictionary
(skk-search-server skk-aux-large-jisyo 10000)  ; skkserv
```

`skk-search` walks this list and accumulates candidates with `skk-nunion`
(a dedup-preserving union, `equal`-based), so the personal dictionary's
entries always rank ahead of the system/server dictionary, with duplicates
removed. In short, ddskk **merges, personal-first** rather than taking the
first hit.

## Changes

- Add `nskk-search-merge-user-dict-with-server` (default `nil`).
  - `nil` (default): unchanged — skkserv takes priority, no behavior change.
  - non-nil: the local dictionary is searched first and its candidates are
    merged ahead of skkserv's, with duplicates removed (ddskk-like).
- Extract `nskk--core-dict-and-server` to combine the local dict and skkserv
  per the option; the default branch preserves the historical server-first
  fallback.
- Add `nskk--merge-candidates-user-first` (user-first dedup merge via
  `delete-dups`).

With the option enabled, the example above yields `(優響 雪 行き)`.

## Testing

- The existing `server hit takes priority: dict candidates are not used`
  integration test is unchanged and still passes (default behavior preserved).
- New opt-in merge tests (user-first order, dedup, server fallback on
  user-dict miss) using the in-process mock skkserv.
- `make compile` clean (warnings-as-errors), `make test` → **5664 / 5664
  passed**, `make lint` (checkdoc) clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)