### PR TITLE
security: protect user dictionary from destructive overwrites

### DIFF
--- a/src/nskk-dictionary.el
+++ b/src/nskk-dictionary.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -134,6 +133,27 @@ Possible values:
 ;;; Section 1: Error types
 
 (define-error 'nskk-dict-error "Dictionary error")
+
+;;; Atomic file writing
+
+(defmacro nskk-dict-with-atomic-file (path &rest body)
+  "Write BODY's temp-buffer output to PATH atomically and privately.
+Like `with-temp-file', but the content is first written to a
+same-directory temp file (created with 600 permissions by
+`make-temp-file') and then renamed over PATH, so a crash or full disk
+mid-write can never leave PATH truncated.  Used for the persisted user
+data files (jisyo, study data, learning scores) and the dict cache."
+  (declare (indent 1) (debug (form body)))
+  (let ((path-sym (make-symbol "path"))
+        (tmp-sym  (make-symbol "tmp")))
+    `(let* ((,path-sym ,path)
+            (,tmp-sym  (make-temp-file (concat ,path-sym "."))))
+       (unwind-protect
+           (progn
+             (with-temp-file ,tmp-sym ,@body)
+             (rename-file ,tmp-sym ,path-sym t))
+         (when (file-exists-p ,tmp-sym)
+           (delete-file ,tmp-sym))))))
 
 ;;; Section 2: Prolog infrastructure
 
@@ -496,7 +516,7 @@ ENTRIES is a list of (kana . candidates-list) pairs.
 DICT-FILES is the list of source files used to build the cache."
   (let ((cache-path (nskk--dict-cache-file-path)))
     (make-directory (file-name-directory cache-path) t)
-    (with-temp-file cache-path
+    (nskk-dict-with-atomic-file cache-path
       (prin1 (list :version 1
                    :source-files dict-files
                    :entries entries)
@@ -684,21 +704,36 @@ consonants appended to KEY.  Results from both searches are combined."
   "Attempt to register WORD for READING in the Prolog user dictionary.
 Returns t on success (Prolog dict-register/2 succeeded), nil on failure."
   (unless nskk--user-dict-index
-    (nskk-prolog-set-index 'user-dict-entry 2 :trie)
-    (setq nskk--user-dict-index 'user))
+    ;; Load any on-disk entries before the first registration: the save
+    ;; path overwrites `nskk-dict-user-dictionary-file' with the current
+    ;; Prolog facts, so registering into an empty database and saving
+    ;; would silently drop every entry not yet loaded from the file.
+    (setq nskk--user-dict-index (nskk-dict-load-user-dictionary))
+    (unless nskk--user-dict-index
+      (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+      (setq nskk--user-dict-index 'user)))
   (when (nskk-prolog-holds-p `(dict-register ,reading ,word))
     (setq nskk-dict-modified t)
     (nskk--dict-run-update-hook)
     (message "NSKK: Registered %s -> %s" reading word)
     t))
 
+(defconst nskk--dict-invalid-key-regexp "[\n\r /▽▼]"
+  "Characters rejected in user-dictionary keys.
+Whitespace, slash and newlines would corrupt the SKK file format
+\(\"KEY /cand1/cand2/\" per line); the ▽/▼ markers indicate preedit
+text leaked into a reading and must never reach the dictionary.")
+
 (defun/k nskk-dict-register-word (reading word)
   "Register WORD as a conversion candidate for READING in user dictionary.
 Uses the Prolog dict-register rule which handles both new entries
 and updates to existing entries via assertz/retract builtins.
 Returns non-nil (t) on success; calls on-not-found when READING or WORD
-are empty/invalid or when the Prolog registration query fails."
+are empty/invalid, when READING contains characters that would corrupt
+the SKK dictionary format (see `nskk--dict-invalid-key-regexp'), or
+when the Prolog registration query fails."
   (if (and (stringp reading) (not (string-empty-p reading))
+           (not (string-match-p nskk--dict-invalid-key-regexp reading))
            (stringp word)   (not (string-empty-p word))
            (nskk--dict-register-impl reading word))
       (succeed t)
@@ -728,15 +763,31 @@ are empty/invalid or when the Prolog unregistration query fails."
 
 ;;; User Dictionary Save
 
+(defvar nskk--dict-save-inhibited nil
+  "Non-nil while saving the user dictionary is temporarily inhibited.
+The tutorial sets this while its mini dictionary replaces the real
+`user-dict-entry' Prolog facts; saving during that window would
+overwrite the personal dictionary file with tutorial data.")
+
 ;;;###autoload
 (defun nskk-dict-save-user-dictionary ()
-  "Save user dictionary to `nskk-dict-user-dictionary-file'."
+  "Save user dictionary to `nskk-dict-user-dictionary-file'.
+Does nothing while `nskk--dict-save-inhibited' is non-nil."
   (interactive)
+  (if nskk--dict-save-inhibited
+      (message "NSKK: User dictionary save inhibited (tutorial active)")
+    (nskk--dict-save-user-dictionary-1)))
+
+(defun nskk--dict-save-user-dictionary-1 ()
+  "Write the current user-dictionary facts to disk unconditionally."
   (when (and nskk-dict-user-dictionary-file nskk--user-dict-index)
+    ;; The personal dictionary records what the user types; keep newly
+    ;; created files and directories private (existing modes are kept).
     (let ((dir (file-name-directory nskk-dict-user-dictionary-file)))
       (unless (file-directory-p dir)
-        (make-directory dir t)))
-    (with-temp-file nskk-dict-user-dictionary-file
+        (with-file-modes #o700
+          (make-directory dir t))))
+    (nskk-dict-with-atomic-file nskk-dict-user-dictionary-file
       (insert ";; -*- mode: fundamental; coding: utf-8 -*-\n")
       (insert ";; NSKK user dictionary\n")
       (insert ";; okuri-nasi entries.\n")
@@ -748,7 +799,12 @@ are empty/invalid or when the Prolog unregistration query fails."
             (let ((safe-cands (seq-remove
                                (lambda (c) (string-match-p "[\n\r/]" c))
                                candidates)))
-              (when (and (not (string-match-p "[\n\r]" key))
+              ;; Never drop data silently: SKK-format-breaking candidates
+              ;; are skipped, but the user should know.
+              (when (< (length safe-cands) (length candidates))
+                (message "NSKK: %d candidate(s) for %s not saved (contain / or newline)"
+                         (- (length candidates) (length safe-cands)) key))
+              (when (and (not (string-match-p nskk--dict-invalid-key-regexp key))
                          safe-cands)
                 (insert (format "%s /%s/\n"
                                 key

--- a/src/nskk-study.el
+++ b/src/nskk-study.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -54,6 +53,7 @@
 (require 'subr-x)
 (require 'seq)
 (require 'nskk-prolog)
+(require 'nskk-dictionary)
 
 ;;;; Customization
 
@@ -206,8 +206,11 @@ of the list.  Returns the (possibly reordered) candidate list."
       (progn
         (let ((dir (file-name-directory nskk-study-file)))
           (unless (file-directory-p dir)
-            (make-directory dir t)))
-        (with-temp-file nskk-study-file
+            ;; Study data records the user's conversion history; keep the
+            ;; directory private when this code has to create it.
+            (with-file-modes #o700
+              (make-directory dir t))))
+        (nskk-dict-with-atomic-file nskk-study-file
           (let ((solutions (nskk-prolog-query '(study-association \?p \?r \?c))))
             (prin1
              (mapcar (lambda (sol)

--- a/src/nskk-tutorial.el
+++ b/src/nskk-tutorial.el
@@ -5,7 +5,6 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
 ;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
@@ -1196,7 +1195,7 @@ Called from `post-command-hook'."
 (defun nskk-tutorial-quit ()
   "Quit the tutorial and restore Prolog state."
   (interactive)
-  (when (yes-or-no-p "チュートリアルを終了しますか？ ")
+  (when (yes-or-no-p "チュートリアルを終了しますか? ")
     (kill-buffer (current-buffer))))
 
 (defun nskk-tutorial--reset-mode ()
@@ -1258,15 +1257,20 @@ within this buffer for practicing SKK operations.
   (setq buffer-read-only nil)
   (add-hook 'post-command-hook #'nskk-tutorial--validate-exercises nil t)
   (add-hook 'kill-buffer-hook #'nskk-tutorial--on-kill nil t)
-  ;; Prevent dict save during tutorial
-  (remove-hook 'kill-emacs-hook #'nskk--dict-maybe-save))
+  ;; Prevent dict save during tutorial: the mini dictionary replaces the
+  ;; real user-dict facts, so saving would overwrite the personal jisyo.
+  ;; A flag is used instead of removing `nskk--dict-maybe-save' from
+  ;; `kill-emacs-hook' because `nskk--enable' (run by the `nskk-mode 1'
+  ;; that follows in the entry point) re-adds that hook, silently undoing
+  ;; a remove-hook based protection.
+  (setq nskk--dict-save-inhibited t))
 
 (defun nskk-tutorial--on-kill ()
-  "Buffer kill hook: restore Prolog state and re-register dict save hook."
+  "Buffer kill hook: restore Prolog state and re-enable dict saving."
   (when nskk-mode
     (ignore-errors (nskk-mode -1)))
   (nskk-tutorial--restore-prolog-state)
-  (add-hook 'kill-emacs-hook #'nskk--dict-maybe-save))
+  (setq nskk--dict-save-inhibited nil))
 
 
 ;;;;

--- a/test/nskk-test-framework.el
+++ b/test/nskk-test-framework.el
@@ -55,6 +55,17 @@
 ;; tests. Most unit and integration tests only need small mock dictionaries.
 (setq nskk-dict-use-ja-dic nil)
 
+;; Isolate the user dictionary from the developer's real ~/.nskk/jisyo.
+;; Registration tests set `nskk-dict-modified', and `nskk--dict-maybe-save'
+;; fires from `kill-emacs-hook' when the batch ERT run exits, overwriting
+;; whatever `nskk-dict-user-dictionary-file' points at with the in-memory
+;; Prolog facts.  A non-existent temp path keeps loads a no-op (matching
+;; the previous behavior for tests that bind the variable to nil) while
+;; redirecting any save away from the real personal dictionary.
+(setq nskk-dict-user-dictionary-file
+      (make-temp-name (expand-file-name "nskk-test-jisyo-"
+                                        temporary-file-directory)))
+
 ;; NOTE: The initialization calls below are guarded by idempotency flags
 ;; (e.g., `nskk--state-prolog-initialized').  If you `eval-buffer' this
 ;; file after editing, those flags will prevent re-initialization unless

--- a/test/unit/nskk-dictionary-test.el
+++ b/test/unit/nskk-dictionary-test.el
@@ -46,7 +46,11 @@
     (should (get 'nskk-dictionary 'group-documentation)))
 
   (nskk-it "nskk-dict-user-dictionary-file defaults to ~/.nskk/jisyo"
-    (should (equal (default-value 'nskk-dict-user-dictionary-file)
+    ;; Check the declared defcustom standard value, not the current value:
+    ;; the test framework redirects the live variable to a temp path so
+    ;; batch runs never touch the real personal dictionary.
+    (should (equal (eval (car (get 'nskk-dict-user-dictionary-file
+                                   'standard-value)))
                    (expand-file-name "~/.nskk/jisyo")))))
 
 (nskk-describe "error condition chains"
@@ -719,7 +723,62 @@
              (nskk-dict-modified nil)
              (nskk-jisyo-update-hook (list (lambda () (setq hook-called t)))))
         (nskk-dict-register-word "てすと" "テスト")
-        (should hook-called)))))
+        (should hook-called))))
+
+  (nskk-it "rejects keys that would corrupt the SKK file format"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+      (let ((nskk--user-dict-index nil)
+            (nskk-dict-modified nil))
+        ;; Space and slash break the "KEY /cand/" line format; newlines
+        ;; break the line structure itself.
+        (should (null (nskk-dict-register-word "て すと" "テスト")))
+        (should (null (nskk-dict-register-word "て/すと" "テスト")))
+        (should (null (nskk-dict-register-word "て\nすと" "テスト")))
+        (should-not nskk-dict-modified))))
+
+  (nskk-it "rejects keys containing leaked preedit markers"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+      (let ((nskk--user-dict-index nil)
+            (nskk-dict-modified nil))
+        (should (null (nskk-dict-register-word "▽てすと" "テスト")))
+        (should (null (nskk-dict-register-word "▼てすと" "テスト")))
+        (should-not nskk-dict-modified))))
+
+  (nskk-it "save is a no-op while nskk--dict-save-inhibited is non-nil"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+      (let* ((tmp (make-temp-file "nskk-save-inhibit-"))
+             (nskk-dict-user-dictionary-file tmp)
+             (nskk--user-dict-index 'user)
+             (nskk-dict-modified t)
+             (nskk--dict-save-inhibited t))
+        (unwind-protect
+            (progn
+              (nskk-prolog-assert '((user-dict-entry "みに" ("ミニ"))))
+              (nskk-dict-save-user-dictionary)
+              ;; Nothing written, modified flag untouched.
+              (should (= 0 (file-attribute-size (file-attributes tmp))))
+              (should nskk-dict-modified)
+              ;; Lifting the inhibit writes normally.
+              (setq nskk--dict-save-inhibited nil)
+              (nskk-dict-save-user-dictionary)
+              (should (> (file-attribute-size (file-attributes tmp)) 0))
+              (should-not nskk-dict-modified))
+          (delete-file tmp)))))
+
+  (nskk-it "registered okuri-ari style key is found by stem lookup (round-trip)"
+    (nskk-prolog-test-with-isolated-db
+      (nskk-prolog-set-index 'user-dict-entry 2 :trie)
+      (let ((nskk--user-dict-index nil)
+            (nskk-dict-modified nil))
+        ;; Okurigana registration stores the dictionary key ("はしr"),
+        ;; which the okuri-ari lookup finds by appending consonants.
+        ;; (Single-char stems skip okuri-ari search by design.)
+        (nskk-dict-register-word "はしr" "走")
+        (let ((result (nskk-dict-lookup "はし")))
+          (should (member "走" result)))))))
 
 ;;; Section 8: CPS /k variant tests
 


### PR DESCRIPTION
## Summary
Audit found four independent paths that could destroy `~/.nskk/jisyo` (and one of them **did**, during batch test runs — test-generated entries were written over the real personal dictionary via `kill-emacs-hook`).

- **Test isolation**: the test framework now redirects `nskk-dict-user-dictionary-file` to a non-existent temp path; batch ERT can no longer touch the real jisyo.
- **Load-before-first-register**: registering with the dictionary not yet loaded then saving used to overwrite the file with only the in-memory facts.
- **Tutorial save-hook re-arm**: `nskk-tutorial-mode` removed the save hook but the following `(nskk-mode 1)` re-added it, so quitting Emacs mid-tutorial could overwrite the jisyo with the 40-entry mini dict. Replaced with a `nskk--dict-save-inhibited` flag checked inside the save function itself.
- **Atomic private persistence**: new `nskk-dict-with-atomic-file` macro (same-directory 600-perm temp file + rename) for jisyo/study/cache writes; created directories are 700. A crash or full disk mid-write can no longer truncate the file.
- Registration rejects SKK-format-breaking keys (space, `/`, newline) and leaked preedit markers (▽/▼); saves report instead of silently dropping unsavable candidates.

## Test plan
- Branch suite: unit 4120/4120, e2e 1012/1012, compile (error-on-warn) + checkdoc clean for touched files.
- New regression tests: save-inhibit no-op, invalid-key rejection (format chars + markers), okuri-ari round-trip, standard-value check for the redirected defcustom.
- Verified the real `~/.nskk/jisyo` mtime is untouched across full test runs after the fix.