### PR TITLE
fix: register okurigana words under the dictionary key; keep okuri kana on undo

### DIFF
--- a/src/nskk-henkan.el
+++ b/src/nskk-henkan.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -449,6 +448,14 @@ always pass both continuation arguments explicitly."
 (defconst nskk-henkan-active-marker-regexp (regexp-quote nskk-henkan-active-marker)
   "Pre-computed regexp for henkan-active marker.")
 
+(defvar nskk--registration-display-reading nil
+  "Display-format reading shown in the registration prompt, or nil.
+Okurigana registrations bind this to the \"stem*kana\" display form
+\(e.g. \"ほ*け\") while the reading passed to `nskk-start-registration'
+is the dictionary key (e.g. \"ほk\").  The dictionary key is what lookup
+uses, so it must be what gets registered; the display form is only for
+the minibuffer prompt.")
+
 (defconst nskk-okurigana-marker-regexp (regexp-quote nskk-okurigana-marker)
   "Pre-computed regexp for okurigana boundary marker.")
 
@@ -724,6 +731,7 @@ through to `undo'."
             (candidates     (plist-get record :candidates))
             (index          (plist-get record :index))
             (committed-text (plist-get record :committed-text))
+            (okuri-kana     (plist-get record :okuri-kana))
             (buf-start      (plist-get record :buffer-start))
             (buf-end        (plist-get record :buffer-end))
             (registered-p   (plist-get record :registered-p))
@@ -747,10 +755,14 @@ through to `undo'."
               (let ((candidate (nth index candidates)))
                 (when candidate
                   (insert (substring-no-properties candidate))))
-              ;; Set up conversion overlay.
+              ;; Set up conversion overlay.  The overlay covers only the
+              ;; candidate; okurigana kana is re-inserted after it, matching
+              ;; the live ▼ layout so a re-commit captures the suffix again.
               (let ((ov-start (+ buf-start
                                  (length nskk-henkan-active-marker)))
                     (ov-end   (point)))
+                (when okuri-kana
+                  (insert okuri-kana))
                 (nskk--set-conversion-start-marker buf-start)
                 (nskk--update-overlay
                  ov-start ov-end (nth index candidates)))
@@ -766,7 +778,12 @@ through to `undo'."
                  nskk-current-state 'active)
                 (nskk-state-put-metadata
                  nskk-current-state
-                 'henkan-reading reading)))
+                 'henkan-reading reading)
+                (when okuri-kana
+                  (nskk-state-put-metadata
+                   nskk-current-state 'okurigana-in-progress t)
+                  (nskk-state-put-metadata
+                   nskk-current-state 'okurigana-query reading))))
           (message "NSKK: Cannot undo kakutei -- buffer has changed"))))))
 
 (defun nskk--invalidate-undo-kakutei ()
@@ -1107,6 +1124,7 @@ in place and will immediately follow the inserted candidate."
                       :candidates candidates
                       :index index
                       :committed-text committed-with-okuri
+                      :okuri-kana okuri-kana
                       :buffer-start start
                       :buffer-end (point)
                       :mode mode
@@ -1393,13 +1411,16 @@ candidates are found."
             (nskk--apply-okuri-candidates start text-start preedit-end candidates query)
             (funcall on-found candidates))
           (lambda ()
-            (let ((reading (nskk--build-okuri-registration-reading
-                            text-start preedit-end query)))
+            ;; Register under the dictionary key QUERY (e.g. "ほk"), the
+            ;; same key lookup uses; the "stem*kana" form is display-only.
+            (let ((nskk--registration-display-reading
+                   (nskk--build-okuri-registration-reading
+                    text-start preedit-end query)))
               (nskk--remove-okuri-marker (or text-start start) preedit-end)
-              (nskk-start-registration/k reading
+              (nskk-start-registration/k query
                 (lambda (registered)
                   (if registered
-                      (nskk--insert-registered-and-reset registered start on-register reading)
+                      (nskk--insert-registered-and-reset registered start on-register query)
                     (funcall on-not-found)))
                 #'ignore)))))
       on-not-found)))
@@ -1533,8 +1554,12 @@ Delegates to `nskk--start-conversion-normal' for the main pipeline."
                  (nskk-state-get-okurigana nskk-current-state))))
     (if okuri
         (let ((preedit-end (save-excursion
-                             (search-backward nskk-okurigana-marker nil t)
-                             (1+ (point)))))
+                             ;; When no * marker exists (okurigana state set
+                             ;; but marker already consumed), fall back to
+                             ;; point instead of a bogus (1+ (point)).
+                             (if (search-backward nskk-okurigana-marker nil t)
+                                 (1+ (point))
+                               (point)))))
           (nskk-with-current-state
             (nskk-state-set-okurigana nskk-current-state nil))
           (nskk--trigger-okuri-conversion/k okuri preedit-end on-found on-not-found on-register))
@@ -1559,8 +1584,8 @@ DEPTH 1 → \"[辞書登録] READING: \", DEPTH 2 → \"[[辞書登録]] READING
 
 (defun nskk--read-registration-entry-with-kana (prompt)
   "Read a registration entry from the minibuffer for PROMPT with nskk-mode active.
-Sets up a dedicated keymap so RET and C-j commit the current conversion
-instead of exiting with a raw newline."
+Sets up a dedicated keymap so \\`RET' and \\`C-j' commit the current
+conversion instead of exiting with a raw newline."
   (let* ((exit-fn (lambda ()
                     (interactive)
                     (let ((phase (nskk--compute-phase)))
@@ -1584,14 +1609,15 @@ instead of exiting with a raw newline."
 (defun nskk--read-registration-entry (reading)
   "Read a registration entry for READING from the minibuffer.
 Returns the entered non-empty string, or nil if the user cancels
-\(empty input or C-g).
+\(empty input or \\`C-g').
 Uses `nskk-use-kana-in-registration' to choose the input method."
   (condition-case nil
-      (let ((entry (if nskk-use-kana-in-registration
-                      (nskk--read-registration-entry-with-kana
-                       (nskk--registration-prompt nskk--registration-depth reading))
-                    (read-from-minibuffer
-                     (nskk--registration-prompt nskk--registration-depth reading)))))
+      (let* ((shown (or nskk--registration-display-reading reading))
+             (entry (if nskk-use-kana-in-registration
+                        (nskk--read-registration-entry-with-kana
+                         (nskk--registration-prompt nskk--registration-depth shown))
+                      (read-from-minibuffer
+                       (nskk--registration-prompt nskk--registration-depth shown)))))
         (and (not (string-empty-p entry)) entry))
     (quit nil)))
 
@@ -1669,16 +1695,19 @@ If the user cancels, wrap around to the first candidate in list display."
          (text (when (and text-start (> (point) text-start))
                  (buffer-substring-no-properties text-start (point)))))
     (if text
-        (let ((reading
-               (if (nskk-with-current-state
-                     (nskk-state-get-metadata nskk-current-state 'okurigana-in-progress))
-                   (let* ((query (nskk-with-current-state
-                                   (nskk-state-get-metadata nskk-current-state 'okurigana-query)))
-                          (okuri-kana (buffer-substring-no-properties
-                                       (overlay-end nskk--conversion-overlay) (point)))
-                          (stem (substring query 0 (- (length query) 1))))
-                     (concat stem nskk-okurigana-marker okuri-kana))
-                 text)))
+        (let* ((query (and (nskk-with-current-state
+                             (nskk-state-get-metadata nskk-current-state 'okurigana-in-progress))
+                           (nskk-with-current-state
+                             (nskk-state-get-metadata nskk-current-state 'okurigana-query))))
+               ;; Register under the dictionary key ("ほk" for okurigana,
+               ;; the plain reading otherwise) — the key lookup uses.
+               (reading (if (stringp query) query text))
+               (nskk--registration-display-reading
+                (when (stringp query)
+                  (let ((okuri-kana (buffer-substring-no-properties
+                                     (overlay-end nskk--conversion-overlay) (point)))
+                        (stem (substring query 0 (- (length query) 1))))
+                    (concat stem nskk-okurigana-marker okuri-kana)))))
           (nskk-start-registration/k reading
             (lambda (registered)
               (if registered

--- a/test/unit/nskk-henkan-test.el
+++ b/test/unit/nskk-henkan-test.el
@@ -2549,7 +2549,36 @@
                           (run-hook-with-args #'ignore))
           (nskk--exhaust-candidates/k (lambda () (setq on-done-called t))))
         (should (equal registration-text "かんじ"))
-        (should on-done-called)))))
+        (should on-done-called))))
+
+  (nskk-it "registers under the okurigana dict key, showing stem*kana in the prompt"
+    (with-temp-buffer
+      (let ((nskk-current-state (nskk-state-create 'hiragana))
+            (nskk--conversion-start-marker (make-marker))
+            (nskk--conversion-overlay nil)
+            (nskk--henkan-candidate-list-active t)
+            registration-text display-reading)
+        (insert nskk-henkan-active-marker "ほけ")
+        (set-marker nskk--conversion-start-marker (point-min))
+        (goto-char (point-max))
+        ;; Overlay covers the stem "ほ"; the okuri kana "け" follows it.
+        (setq nskk--conversion-overlay (make-overlay 2 3))
+        (nskk-state-force-henkan-phase nskk-current-state 'active)
+        (nskk-state-set-candidates nskk-current-state '("褒"))
+        (nskk-state-put-metadata nskk-current-state 'okurigana-in-progress t)
+        (nskk-state-put-metadata nskk-current-state 'okurigana-query "ほk")
+        (nskk-with-mocks ((nskk-start-registration/k
+                           (lambda (text on-done _ignored)
+                             (setq registration-text text
+                                   display-reading nskk--registration-display-reading)
+                             (funcall on-done nil)))  ; registration cancelled
+                          (nskk--wrap-to-first-candidate #'ignore)
+                          (run-hook-with-args #'ignore))
+          (nskk--exhaust-candidates/k #'ignore))
+        ;; Dictionary key, not the display form, must be registered:
+        ;; lookup appends okuri consonants to the stem ("ほ" + "k").
+        (should (equal registration-text "ほk"))
+        (should (equal display-reading "ほ*け"))))))
 
 ;;;
 ;;; nskk-cancel-conversion/k Tests
@@ -4228,6 +4257,38 @@
       (should (string-match-p "▼漢字"
                               (buffer-substring-no-properties
                                (point-min) (point-max))))))
+
+  (nskk-it "restores the okurigana suffix after the candidate"
+    (with-temp-buffer
+      (setq-local nskk-current-state (nskk-state-create 'hiragana))
+      ;; Committed okurigana conversion: candidate "書" + okuri "く".
+      (insert "書く")
+      (setq nskk--last-kakutei-record
+            (list :reading "かk"
+                  :candidates '("書" "描")
+                  :index 0
+                  :committed-text "書く"
+                  :okuri-kana "く"
+                  :buffer-start 1
+                  :buffer-end 3
+                  :mode 'hiragana
+                  :registered-p nil
+                  :registered-reading nil
+                  :registered-word nil))
+      (nskk-undo-kakutei)
+      ;; The okurigana kana must survive the undo: ▼ + 書 + く.
+      (should (equal "▼書く"
+                     (buffer-substring-no-properties
+                      (point-min) (point-max))))
+      ;; Overlay covers only the candidate, not the okuri kana.
+      (should (overlayp nskk--conversion-overlay))
+      (should (= (overlay-end nskk--conversion-overlay) 3))
+      ;; Okurigana metadata restored for consistent follow-up commits.
+      (should (nskk-state-get-metadata nskk-current-state
+                                       'okurigana-in-progress))
+      (should (equal "かk"
+                     (nskk-state-get-metadata nskk-current-state
+                                              'okurigana-query)))))
 
   (nskk-it "does not revert when buffer text has changed"
     (with-temp-buffer


### PR DESCRIPTION
## Summary
Two okurigana correctness bugs in the henkan layer:

- **Registration stored an unfindable key**: the display-format reading (`ほ*け`) was registered verbatim, but lookup only queries the SKK key format (`ほk`/`わるi`) — so words registered through the okurigana path were persisted yet never appeared as candidates again. The minibuffer prompt still shows `stem*kana` (new `nskk--registration-display-reading`), while the registered key — and the undo-unregister key — is now the lookup query.
- **`nskk-undo-kakutei` lost the okuri kana**: committing 書く then undoing restored `▼書`; the く was gone for good. The undo record now carries `:okuri-kana`, restore re-inserts it after the candidate overlay, and okurigana metadata is restored for consistent follow-up commits.
- Bonus hardening: `nskk-start-conversion/k` no longer computes a bogus `preedit-end` when the `*` marker is absent (unchecked `search-backward`).

## Test plan
- Branch suite: unit 4118/4118, e2e 1012/1012, compile (error-on-warn) clean.
- New regression tests: exhaust-candidates okuri path registers under the query key with `ほ*け` as prompt display; undo restores `▼書く` with the overlay covering only the candidate and okurigana metadata set.