### PR TITLE
security: bound skkserv connection setup and response size

### DIFF
--- a/src/nskk-server.el
+++ b/src/nskk-server.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -166,6 +165,14 @@ Managed by `nskk-server-open' and `nskk-server-close'.")
 (defconst nskk--server-buffer-name " *nskk-server*"
   "Name of the working buffer for skkserv I/O.")
 
+(defconst nskk--server-max-response-size (* 1024 1024)
+  "Maximum size, in bytes, of a single skkserv response.
+A well-formed skkserv reply is terminated by a newline and is far smaller
+than this cap.  If the accumulated response exceeds this size without a
+terminating newline, `nskk--server-await-response' treats the reply as a
+protocol error: it resets the connection and fails.  This bounds memory
+use against a misbehaving or malicious server that never sends a newline.")
+
 (defvar nskk--server-kill-emacs-hook-registered nil
   "Non-nil when `nskk-server-close' is registered on `kill-emacs-hook'.
 Used to avoid duplicate registrations (idempotent guard).")
@@ -200,16 +207,38 @@ Returns nil when not connected or when `nskk--server-process' is nil."
 (defun nskk--server-make-connection ()
   "Open a raw TCP connection to the configured skkserv instance.
 Returns the process object on success, or nil if the connection fails.
-Binds coding system for both read and write directions."
+
+Connects asynchronously with `:nowait' so that a host which blackholes
+incoming SYNs cannot freeze Emacs for the OS-level connect timeout
+\(~75 seconds) on every lookup.  After initiating the connection, the
+process status is polled with `accept-process-output' until it becomes
+\\='open, bounded by `nskk-server-timeout'.  If the deadline passes or the
+status becomes \\='failed or \\='closed, the half-open process is deleted
+and nil is returned (treated by callers as a connection failure).
+
+Binds coding system for both read and write directions.  Because the
+connection is plain TCP (no TLS negotiation), `:nowait' is safe here."
   (condition-case err
-      (let ((coding-system-for-read  nskk-server-coding-system)
-            (coding-system-for-write nskk-server-coding-system))
-        (open-network-stream
-         "nskk-server"
-         (get-buffer-create nskk--server-buffer-name)
-         nskk-server-host
-         nskk-server-portnum
-         :type 'plain))
+      (let* ((coding-system-for-read  nskk-server-coding-system)
+             (coding-system-for-write nskk-server-coding-system)
+             (proc (open-network-stream
+                    "nskk-server"
+                    (get-buffer-create nskk--server-buffer-name)
+                    nskk-server-host
+                    nskk-server-portnum
+                    :type 'plain
+                    :nowait t))
+             (deadline (+ (float-time) nskk-server-timeout)))
+        (while (and (eq (process-status proc) 'connect)
+                    (< (float-time) deadline))
+          (accept-process-output proc 0.1))
+        (if (eq (process-status proc) 'open)
+            proc
+          (nskk-debug-message
+           "nskk-server-open: connection to %s:%d not established (status=%s)"
+           nskk-server-host nskk-server-portnum (process-status proc))
+          (delete-process proc)
+          nil))
     (error
      (nskk-debug-message "nskk-server-open: connection failed: %s"
                          (error-message-string err))
@@ -328,17 +357,38 @@ Fails for not-found responses, empty responses, or non-string inputs."
 (defun/k nskk--server-await-response (proc buf deadline)
   "Poll PROC via BUF for a complete skkserv response line until DEADLINE.
 Polls at 0.1-second intervals using `accept-process-output'.
+
+Searches the process buffer directly for the terminating newline instead
+of copying its whole contents on every poll, and enforces
+`nskk--server-max-response-size' as an upper bound on the accumulated
+reply.  When that cap is exceeded without a newline, the response is
+treated as a protocol error: the connection is reset via
+`nskk-server-close' and the function fails.
+
 Succeeds with the accumulated response string (containing a newline).
-Fails on timeout or disconnection."
-  (let (response)
-    (while (and (nskk-server-live-p)
-                (< (float-time) deadline)
-                (not (and response (string-search "\n" response))))
+Fails on timeout, disconnection, or oversized response."
+  (let ((found nil)
+        (overflow nil))
+    (while (and (not found)
+                (not overflow)
+                (nskk-server-live-p)
+                (< (float-time) deadline))
       (accept-process-output proc 0.1)
-      (setq response (with-current-buffer buf (buffer-string))))
-    (if (and response (string-search "\n" response))
-        (succeed response)
-      (fail))))
+      (with-current-buffer buf
+        (goto-char (point-min))
+        (cond
+         ((search-forward "\n" nil t) (setq found t))
+         ((> (buffer-size) nskk--server-max-response-size)
+          (setq overflow t)))))
+    (cond
+     (overflow
+      (nskk-debug-message
+       "nskk-server-lookup: response exceeded %d bytes without newline; resetting connection"
+       nskk--server-max-response-size)
+      (nskk-server-close)
+      (fail))
+     (found (succeed (with-current-buffer buf (buffer-string))))
+     (t (fail)))))
 
 (defun/k nskk--server-with-response (key)
   "Send skkserv command 1 for KEY, await the response.

--- a/test/unit/nskk-server-test.el
+++ b/test/unit/nskk-server-test.el
@@ -311,6 +311,7 @@ Restores server-state to closed in an unwind-protect."
                          (lambda (_name _buf host port &rest _)
                            (setq received-host host received-port port)
                            'mock-proc))
+                        (process-status (lambda (_) 'open))
                         (set-process-query-on-exit-flag (lambda (&rest _) nil))
                         (process-buffer (lambda (_) nil)))
         (unwind-protect
@@ -326,6 +327,7 @@ Restores server-state to closed in an unwind-protect."
           (nskk--server-process nil)
           (nskk--server-kill-emacs-hook-registered t))
       (nskk-with-mocks ((open-network-stream (lambda (&rest _) 'new-proc))
+                        (process-status (lambda (_) 'open))
                         (set-process-query-on-exit-flag (lambda (&rest _) nil))
                         (process-buffer (lambda (_) nil)))
         (unwind-protect
@@ -341,6 +343,7 @@ Restores server-state to closed in an unwind-protect."
           (nskk--server-process nil)
           (nskk--server-kill-emacs-hook-registered t))
       (nskk-with-mocks ((open-network-stream (lambda (&rest _) 'mock-proc))
+                        (process-status (lambda (_) 'open))
                         (set-process-query-on-exit-flag (lambda (&rest _) nil))
                         (process-buffer (lambda (_) nil)))
         (unwind-protect
@@ -366,6 +369,7 @@ Restores server-state to closed in an unwind-protect."
           (nskk--server-kill-emacs-hook-registered nil)
           (add-hook-count 0))
       (nskk-with-mocks ((open-network-stream (lambda (&rest _) 'mock-proc))
+                        (process-status (lambda (_) 'open))
                         (set-process-query-on-exit-flag (lambda (&rest _) nil))
                         (add-hook (lambda (&rest _) (cl-incf add-hook-count)))
                         (process-buffer (lambda (_) nil)))
@@ -682,7 +686,86 @@ Restores server-state to closed in an unwind-protect."
         (nskk-with-mocks
             ((nskk-server-live-p (lambda () nil))
              (accept-process-output (lambda (&rest _) nil)))
-          (should (null (nskk--server-await-response proc buf deadline))))))))
+          (should (null (nskk--server-await-response proc buf deadline)))))))
+
+  ;; Regression (FIX 2): a server that streams data without ever sending a
+  ;; newline must not accumulate unbounded memory.  Once the buffer exceeds
+  ;; `nskk--server-max-response-size', await-response fails and resets the
+  ;; connection rather than looping until the deadline.
+  (nskk-it "fails and resets the connection when the response exceeds the size cap"
+    (with-temp-buffer
+      (let* ((buf (current-buffer))
+             (proc 'mock-proc)
+             (deadline (+ (float-time) 10))
+             (close-called nil))
+        (nskk-with-mocks
+            ((nskk-server-live-p (lambda () t))
+             (nskk-server-close (lambda () (setq close-called t)))
+             (accept-process-output
+              (lambda (_p _t)
+                ;; Insert one over-cap chunk with no terminating newline.
+                (with-current-buffer buf
+                  (insert (make-string (1+ nskk--server-max-response-size) ?x))))))
+          (should (null (nskk--server-await-response proc buf deadline)))
+          (should close-called)))))
+
+  (nskk-it "still succeeds for a normal-sized response under the cap"
+    (with-temp-buffer
+      (let* ((buf (current-buffer))
+             (proc 'mock-proc)
+             (deadline (+ (float-time) 10))
+             (close-called nil))
+        (nskk-with-mocks
+            ((nskk-server-live-p (lambda () t))
+             (nskk-server-close (lambda () (setq close-called t)))
+             (accept-process-output (lambda (_p _t)
+                                      (with-current-buffer buf
+                                        (insert "1/漢字/\n")))))
+          (let ((result (nskk--server-await-response proc buf deadline)))
+            (should (stringp result))
+            (should (string-match-p "\n" result))
+            (should (null close-called))))))))
+
+;;; ─────────────────────────────────────────────────────────────────────────
+;;; nskk--server-make-connection: async (:nowait) connect + timeout
+;;; ─────────────────────────────────────────────────────────────────────────
+
+(nskk-describe "nskk--server-make-connection async connect"
+  (nskk-it "returns the process object once the connection reaches \\='open"
+    (let ((nskk-server-timeout 5))
+      (nskk-with-mocks
+          ((open-network-stream (lambda (&rest _) 'mock-proc))
+           (get-buffer-create (lambda (_) nil))
+           (process-status (lambda (_) 'open))
+           (accept-process-output (lambda (&rest _) nil)))
+        (should (eq (nskk--server-make-connection) 'mock-proc)))))
+
+  ;; Regression (FIX 1): a blackholed host leaves the process stuck in
+  ;; \\='connect; make-connection must give up at `nskk-server-timeout' and
+  ;; delete the half-open process rather than blocking on the OS timeout.
+  (nskk-it "gives up at the timeout and deletes the process when connect never completes"
+    (let ((nskk-server-timeout 0.3)
+          (deleted-proc nil))
+      (nskk-with-mocks
+          ((open-network-stream (lambda (&rest _) 'stuck-proc))
+           (get-buffer-create (lambda (_) nil))
+           (process-status (lambda (_) 'connect))
+           (accept-process-output (lambda (&rest _) nil))
+           (delete-process (lambda (p) (setq deleted-proc p))))
+        (should (null (nskk--server-make-connection)))
+        (should (eq deleted-proc 'stuck-proc)))))
+
+  (nskk-it "returns nil and deletes the process when connect fails"
+    (let ((nskk-server-timeout 5)
+          (deleted-proc nil))
+      (nskk-with-mocks
+          ((open-network-stream (lambda (&rest _) 'failed-proc))
+           (get-buffer-create (lambda (_) nil))
+           (process-status (lambda (_) 'failed))
+           (accept-process-output (lambda (&rest _) nil))
+           (delete-process (lambda (p) (setq deleted-proc p))))
+        (should (null (nskk--server-make-connection)))
+        (should (eq deleted-proc 'failed-proc))))))
 
 ;;;
 ;;; nskk--server-with-response


### PR DESCRIPTION
## Summary
- **Connect freeze**: connection setup used a synchronous `open-network-stream`; a host that blackholes SYNs froze Emacs for the OS connect timeout (~75s) on **every conversion**. The client now connects with `:nowait t` and polls process status bounded by `nskk-server-timeout` (default 1s), deleting the half-open process and treating it as a dictionary miss on failure.
- **Unbounded response**: the response poll accumulated unbounded data from the socket and re-copied the whole process buffer every 0.1s. Responses are now capped at 1 MiB (`nskk--server-max-response-size`) — exceeding the cap resets the connection and fails the lookup — and the newline scan works directly in the process buffer.

Protocol-injection review came back clean (existing key guard rejects control chars/space; EUC-JP/UTF-8 never emit 0x20/0x0A mid-sequence).

## Test plan
- Branch suite: unit 4121/4121 (server file 73/73, +5 new), server integration 12/12 — including the mock-skkserv test exercising the new `:nowait` connect against a real localhost listener.
- New regression tests: over-cap response fails and resets, under-cap succeeds, async connect success/timeout/failed-status paths.