### PR TITLE
fix: trie key counts, debug index arity, strict :safe predicates

### DIFF
--- a/src/nskk-custom.el
+++ b/src/nskk-custom.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -94,7 +93,7 @@
                  (const :tag "Hiragana" hiragana)
                  (const :tag "Katakana" katakana)
                  (const :tag "Full-width Latin" jisx0208-latin))
-  :safe #'symbolp
+  :safe (lambda (v) (memq v '(ascii hiragana katakana jisx0208-latin)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-state)
 
@@ -120,7 +119,7 @@
 \\='azik     - AZIK extended romaji with efficiency shortcuts"
   :type '(choice (const :tag "Standard SKK" standard)
                  (const :tag "AZIK" azik))
-  :safe #'symbolp
+  :safe (lambda (v) (memq v '(standard azik)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-converter)
 
@@ -138,7 +137,7 @@
   :type '(choice (const :tag "Frequency order" frequency)
                  (const :tag "Kana order" kana)
                  (const :tag "No sorting" none))
-  :safe #'symbolp
+  :safe (lambda (v) (memq v '(frequency kana none)))
   :package-version '(nskk . "0.1.0")
   :group 'nskk-search)
 

--- a/src/nskk-debug.el
+++ b/src/nskk-debug.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -89,7 +88,7 @@
 
 ;; Category routing facts: hash-indexed on the category symbol (position 0)
 ;; for O(1) prefix lookup via `nskk-prolog-query-value'.
-(nskk-prolog-set-index 'debug-category 0 :hash)
+(nskk-prolog-set-index 'debug-category 2 :hash)
 (nskk-prolog-assert '((debug-category input   "[INPUT]")))
 (nskk-prolog-assert '((debug-category henkan  "[HENKAN]")))
 (nskk-prolog-assert '((debug-category search  "[SEARCH]")))

--- a/src/nskk-input.el
+++ b/src/nskk-input.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -229,8 +228,9 @@ correction for plain hiragana input where no ▽ is open."
 (defun nskk--downcase-normal-japanese-effective-char (effective-char normalize-vowel-p
                                                                      continue-vowel-shadow-p)
   "Return EFFECTIVE-CHAR adjusted for normal Japanese input handling.
-Uppercase chars are downcased only when okurigana is pending or when
-CONTINUE-VOWEL-SHADOW-P keeps an explicit deferred reading alive."
+Uppercase chars are downcased only when NORMALIZE-VOWEL-P is nil and
+either okurigana is pending or CONTINUE-VOWEL-SHADOW-P keeps an
+explicit deferred reading alive."
   (if (and (not normalize-vowel-p)
            (characterp effective-char)
            (<= ?A effective-char) (<= effective-char ?Z)

--- a/src/nskk-trie.el
+++ b/src/nskk-trie.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -95,8 +94,15 @@ modest for leaf-heavy subtrees.")
     (unless child
       (setq child (nskk-trie-node--create))
       (puthash char child (nskk-trie-node-children node)))
-    (cl-incf (nskk-trie-node-count child))
     child))
+
+(defun nskk--trie-adjust-path-counts (trie key delta)
+  "Add DELTA to the key count of every node on KEY's path in TRIE.
+Assumes the full path exists."
+  (let ((node (nskk-trie-root trie)))
+    (dotimes (i (length key))
+      (setq node (gethash (aref key i) (nskk-trie-node-children node)))
+      (cl-incf (nskk-trie-node-count node) delta))))
 
 (defun nskk-trie-insert (trie key value)
   "Insert KEY with VALUE into TRIE."
@@ -107,12 +113,16 @@ modest for leaf-heavy subtrees.")
   (let ((node (nskk-trie-root trie))
         (was-new nil))
     (dotimes (i (length key))
-      (setq node (nskk--trie-get-or-create-child node (aref key i))))
+      (setq node (nskk--trie-get-or-create-child node (aref key i)))
+      (cl-incf (nskk-trie-node-count node)))
     (setq was-new (not (nskk-trie-node-is-end node)))
     (setf (nskk-trie-node-is-end node) t)
     (setf (nskk-trie-node-value node) value)
-    (when was-new
-      (cl-incf (nskk-trie-size trie)))
+    (if was-new
+        (cl-incf (nskk-trie-size trie))
+      ;; Re-inserting an existing key: roll back the count bump so node
+      ;; counts stay "number of keys passing through this node".
+      (nskk--trie-adjust-path-counts trie key -1))
     trie))
 
 (defun nskk--trie-find-node (trie key)
@@ -162,6 +172,7 @@ Returns t if deleted, nil if not present."
       (setf (nskk-trie-node-is-end node) nil)
       (setf (nskk-trie-node-value node) nil)
       (cl-decf (nskk-trie-size trie))
+      (nskk--trie-adjust-path-counts trie key -1)
       (nskk--trie-cleanup-path trie key)
       t)))
 


### PR DESCRIPTION
## Summary
Small correctness/hardening batch from the audit:

- **Trie per-node key counts drifted**: re-inserting an existing key inflated counts and deletion never decremented. Duplicate inserts now roll back the bump; deletes decrement along the path (counts stay "keys passing through this node", as the docstring promises).
- **`debug-category` Prolog index registered with arity 0** instead of 2 — the `:hash` index was never consulted.
- **Over-permissive `:safe` predicates**: three enum defcustoms accepted any symbol as a file-local value; each now checks membership in its `:type` set.
- checkdoc: document `NORMALIZE-VOWEL-P` in its docstring.

## Test plan
Branch suite: unit 4116/4116 (trie 70/70), compile (error-on-warn) clean.