### PR TITLE
chore: MELPA header cleanup, README install section, Makefile coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SRC = src/nskk-cps-macros.el src/nskk-prolog.el src/nskk-trie.el \
        src/nskk-server.el src/nskk-program-dictionary.el src/nskk-azik.el \
        src/nskk-annotation.el src/nskk-context.el src/nskk-inline.el \
        src/nskk-isearch.el src/nskk-region.el src/nskk-show-mode.el \
+       src/nskk-study.el src/nskk-tutorial.el \
        src/nskk.el
 
 # Unit test files

--- a/README.org
+++ b/README.org
@@ -43,7 +43,13 @@ No external ELPA packages required.
 - Same conversion markers (▽ for preedit, ▼ for conversion)
 
 * Installation
-** use-package
+** MELPA
+#+begin_src elisp
+;; After nskk is available on MELPA:
+(use-package nskk
+  :ensure t)
+#+end_src
+** From source
 #+begin_src elisp
 (use-package nskk
   :vc (:url "https://github.com/takeokunn/nskk.el" :rev :newest

--- a/src/nskk-annotation.el
+++ b/src/nskk-annotation.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-azik.el
+++ b/src/nskk-azik.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-cache.el
+++ b/src/nskk-cache.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-candidate-window.el
+++ b/src/nskk-candidate-window.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-context.el
+++ b/src/nskk-context.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-converter.el
+++ b/src/nskk-converter.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 ;;

--- a/src/nskk-cps-macros.el
+++ b/src/nskk-cps-macros.el
@@ -5,7 +5,6 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
 ;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.

--- a/src/nskk-inline.el
+++ b/src/nskk-inline.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-isearch.el
+++ b/src/nskk-isearch.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-kana.el
+++ b/src/nskk-kana.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-keymap.el
+++ b/src/nskk-keymap.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-program-dictionary.el
+++ b/src/nskk-program-dictionary.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 ;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/src/nskk-prolog.el
+++ b/src/nskk-prolog.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n, japanese
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-region.el
+++ b/src/nskk-region.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-show-mode.el
+++ b/src/nskk-show-mode.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/src/nskk-state.el
+++ b/src/nskk-state.el
@@ -5,8 +5,7 @@
 ;; Author: takeokunn <bararararatty@gmail.com>
 ;; Maintainer: takeokunn <bararararatty@gmail.com>
 ;; URL: https://github.com/takeokunn/nskk.el
-;; Version: 0.1.0
-;; Keywords: i18n
+;; Keywords: i18n convenience
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
## Summary
MELPA-readiness cleanup:

- Drop redundant `;; Version:` headers from secondary source files (package.el reads only the main file's) and normalize `;; Keywords:` to the standard finder keywords `i18n convenience`. `src/nskk.el` keeps `Version` + `Package-Requires`.
- README: add a MELPA `use-package :ensure t` install subsection alongside the from-source `:vc` instructions.
- Makefile: add `nskk-study.el` and `nskk-tutorial.el` to `SRC` — they were outside byte-compile (error-on-warn) and checkdoc coverage.

The same header cleanup for files touched by the concurrent fix PRs (#52–#56) rides in those PRs; once everything lands, all 28 files are consistent and `make lint` is fully clean (verified on the combined tree: compile 0 warnings, checkdoc 0, package-lint 0, 5682 tests passing).

Note for the eventual MELPA recipe: sources live under `src/`, so the recipe needs `:files ("src/*.el")`.